### PR TITLE
Add SaaS planning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
-install nodejs from https://nodejs.org/
+# Sticky Notes SaaS
 
-install mongodb from https://www.mongodb.org/
+This repository contains the planning material for building a minimalist single page application for managing sticky notes.
 
-checkout or download the code from https://github.com/tylthal/todo
+## Vision
+Create a clean and vibrant web application that lets users manage tasks and ideas using interactive sticky notes.
 
-open a cmd prompt in the base of the project directory and run the following commands:
-* npm install -g gulp gulp-typescript nodemon
-* npm install
-* typings install
-* gulp watch <-- this command will compile the typescript and watch for changes in the project
+## MVP Features
+- User accounts with AWS Cognito authentication
+- Private boards per user
+- Add, edit, delete, drag and resize notes
+- Color coding and text formatting
+- Tagging and free‑text search
+- Attach files and images to notes
+- Share notes privately or publicly with revocable URLs
+- Real‑time collaboration among authenticated users
 
-to run the site open a cmd prompt in the root of the folder and type "npm start"
-then navigate to http://localhost:8080
+## Technical Stack
+- **Frontend:** React.js hosted via AWS Amplify or CloudFront
+- **Backend:** Serverless architecture using AWS Lambda and API Gateway
+- **Database:** DynamoDB
+
+Longer term features like offline capability, integrations, and analytics are detailed in `todo.md`.
+

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,30 @@
+# Development TODO
+
+This file outlines the high-level steps to implement the Sticky Notes SaaS.
+
+## Setup
+- [ ] Initialize Git repository and configure CI/CD
+- [ ] Provision AWS resources (Cognito, DynamoDB, S3/CloudFront, API Gateway, Lambda)
+- [ ] Set up local development environment with Node.js and React
+
+## Backend
+- [ ] Design DynamoDB schema for storing notes, users, and share tokens
+- [ ] Implement REST API with AWS Lambda functions
+- [ ] Secure API endpoints with AWS Cognito authentication
+- [ ] Add real-time update support using WebSockets or AWS AppSync
+
+## Frontend
+- [ ] Bootstrap React single page application
+- [ ] Build sticky note component with drag, drop, and resizing capabilities
+- [ ] Implement login, signup, and session management
+- [ ] Integrate API calls for CRUD operations on notes
+- [ ] Add tagging, search, and color selection UI
+
+## Collaboration and Sharing
+- [ ] Allow users to invite collaborators by email
+- [ ] Generate public share links with ability to revoke
+
+## Future Enhancements
+- [ ] Offline support with automatic sync
+- [ ] Integrations with external tools (Slack, Trello, cloud storage)
+- [ ] Analytics for user engagement


### PR DESCRIPTION
## Summary
- replace project README with new vision and architecture
- add TODO list for implementing the AWS-backed sticky notes app

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840839f11bc832ba4f94fa40391709b