### PR TITLE
Add note canvas and auth placeholders

### DIFF
--- a/packages/frontend/src/AccountControls.tsx
+++ b/packages/frontend/src/AccountControls.tsx
@@ -1,0 +1,20 @@
+import React, { useContext } from 'react';
+import { UserContext } from './UserContext';
+import './App.css';
+
+export const AccountControls: React.FC = () => {
+  const { user, login, logout } = useContext(UserContext);
+
+  return (
+    <div className="account">
+      {user ? (
+        <>
+          <span className="welcome">Hello, {user.name}</span>
+          <button onClick={logout}>Logout</button>
+        </>
+      ) : (
+        <button onClick={login}>Login</button>
+      )}
+    </div>
+  );
+};

--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -60,3 +60,20 @@
 .note .delete:hover {
   color: #dc2626;
 }
+
+.app {
+  padding: 1rem;
+}
+
+.account {
+  margin-bottom: 1rem;
+}
+
+.account button {
+  margin-left: 0.5rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.welcome {
+  margin-right: 0.5rem;
+}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,47 +1,17 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { UserProvider } from './UserContext';
+import { AccountControls } from './AccountControls';
+import { NoteCanvas } from './NoteCanvas';
 import './App.css';
 
-interface Note {
-  id: number;
-  text: string;
-}
-
 const App: React.FC = () => {
-  const [notes, setNotes] = useState<Note[]>([]);
-  const [input, setInput] = useState('');
-
-  const addNote = () => {
-    if (!input.trim()) return;
-    setNotes([...notes, { id: Date.now(), text: input }]);
-    setInput('');
-  };
-
-  const removeNote = (id: number) => {
-    setNotes(notes.filter(n => n.id !== id));
-  };
-
   return (
-    <div className="board">
-      <h1>Sticky Notes</h1>
-      <div className="controls">
-        <input
-          value={input}
-          onChange={e => setInput(e.target.value)}
-          placeholder="Write a note..."
-        />
-        <button onClick={addNote}>Add</button>
+    <UserProvider>
+      <div className="app">
+        <AccountControls />
+        <NoteCanvas />
       </div>
-      <div className="notes">
-        {notes.map(note => (
-          <div key={note.id} className="note">
-            <button className="delete" onClick={() => removeNote(note.id)}>
-              &times;
-            </button>
-            <p>{note.text}</p>
-          </div>
-        ))}
-      </div>
-    </div>
+    </UserProvider>
   );
 };
 

--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { StickyNote } from './StickyNote';
+import './App.css';
+
+interface Note {
+  id: number;
+  text: string;
+}
+
+export const NoteCanvas: React.FC = () => {
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [input, setInput] = useState('');
+
+  const addNote = () => {
+    if (!input.trim()) return;
+    setNotes([...notes, { id: Date.now(), text: input }]);
+    setInput('');
+  };
+
+  const removeNote = (id: number) => {
+    setNotes(notes.filter(n => n.id !== id));
+  };
+
+  return (
+    <div className="board">
+      <h1>Universal Note Canvas</h1>
+      <div className="controls">
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Write a note..."
+        />
+        <button onClick={addNote}>Add</button>
+      </div>
+      <div className="notes">
+        {notes.map(note => (
+          <StickyNote key={note.id} id={note.id} text={note.text} onDelete={removeNote} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export interface StickyNoteProps {
+  id: number;
+  text: string;
+  onDelete: (id: number) => void;
+}
+
+export const StickyNote: React.FC<StickyNoteProps> = ({ id, text, onDelete }) => {
+  return (
+    <div className="note">
+      <button className="delete" onClick={() => onDelete(id)}>&times;</button>
+      <p>{text}</p>
+    </div>
+  );
+};

--- a/packages/frontend/src/UserContext.tsx
+++ b/packages/frontend/src/UserContext.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useState, ReactNode } from 'react';
+
+export interface User {
+  id: string;
+  name: string;
+}
+
+interface UserContextType {
+  user: User | null;
+  login: () => void;
+  logout: () => void;
+}
+
+export const UserContext = createContext<UserContextType>({
+  user: null,
+  login: () => {},
+  logout: () => {}
+});
+
+export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  const login = () => {
+    // placeholder logic for authentication
+    setUser({ id: '1', name: 'Demo User' });
+  };
+
+  const logout = () => setUser(null);
+
+  return (
+    <UserContext.Provider value={{ user, login, logout }}>
+      {children}
+    </UserContext.Provider>
+  );
+};


### PR DESCRIPTION
## Summary
- add `NoteCanvas` and `StickyNote` components that own rendering of notes
- wrap app with `UserProvider` and placeholder account controls
- basic login/logout stub with context
- style updates for account section

## Testing
- `npm test --workspaces`
- `npm run build --workspace=@sticky-notes/frontend`
- `npm run build --workspace=@sticky-notes/backend`

------
https://chatgpt.com/codex/tasks/task_e_684088e53998832bba8c65d79b156437