### PR TITLE
Fix npm workspace scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,5 +67,5 @@ Styles are plain CSS files imported from the React components. To build the
 production bundle for the frontend only, run:
 
 ```bash
-npm run build --workspace frontend
+npm run build --workspace packages/frontend
 ```

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "workspaces": ["packages/*"],
   "scripts": {
-    "dev:frontend": "npm start --workspace frontend",
-    "dev:backend": "npm start --workspace backend",
+    "dev:frontend": "npm start --workspace packages/frontend",
+    "dev:backend": "npm start --workspace packages/backend",
     "build": "npm run build --workspaces"
   }
 }


### PR DESCRIPTION
## Summary
- fix workspace paths in `package.json`
- document correct path for building the frontend

## Testing
- `npm run dev:frontend --silent & sleep 5; kill $!`
- `npm run dev:backend --silent & sleep 2; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_6846170c180c832b80449ce21cbae69d