### PR TITLE
Implement interactive notes

### DIFF
--- a/packages/frontend/src/AccountControls.tsx
+++ b/packages/frontend/src/AccountControls.tsx
@@ -2,11 +2,15 @@ import React, { useContext } from 'react';
 import { UserContext } from './UserContext';
 import './App.css';
 
-export const AccountControls: React.FC = () => {
+export interface AccountControlsProps {
+  onAddNote: () => void;
+}
+export const AccountControls: React.FC<AccountControlsProps> = ({ onAddNote }) => {
   const { user, login, logout } = useContext(UserContext);
 
   return (
     <div className="account">
+      <button className="add-note" onClick={onAddNote}>Add Note</button>
       {user ? (
         <>
           <span className="welcome">Hello, {user.name}</span>

--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -19,21 +19,19 @@
 }
 
 .notes {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  justify-content: flex-start;
+  position: relative;
+  width: 100%;
+  height: calc(100vh - 3rem);
 }
 
 .note {
   background-color: #fff9c4;
   padding: 0.5rem;
-  width: 150px;
-  min-height: 100px;
-  position: relative;
+  position: absolute;
   border-radius: 4px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   word-break: break-word;
+  touch-action: none;
 }
 
 
@@ -56,6 +54,44 @@
   background: transparent;
   cursor: pointer;
   font-size: 1rem;
+}
+
+.note .archive {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.resize-handle {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 16px;
+  height: 16px;
+  background: rgba(0, 0, 0, 0.2);
+  cursor: nwse-resize;
+}
+
+.toolbar {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.toolbar button {
+  padding: 0.25rem;
+  font-size: 0.9rem;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.toolbar button:active {
+  background: #e5e7eb;
 }
 
 .note .delete:hover {
@@ -83,6 +119,10 @@
   border: 1px solid #fff;
   border-radius: 4px;
   cursor: pointer;
+}
+.account .add-note {
+  background-color: #14b8a6;
+  border-color: #14b8a6;
 }
 .account button:hover {
   background-color: rgba(255, 255, 255, 0.2);

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,15 +1,56 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { UserProvider } from './UserContext';
 import { AccountControls } from './AccountControls';
 import { NoteCanvas } from './NoteCanvas';
 import './App.css';
 
+export interface Note {
+  id: number;
+  content: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  archived: boolean;
+}
+
 const App: React.FC = () => {
+  const [notes, setNotes] = useState<Note[]>([]);
+
+  const addNote = () => {
+    const id = Date.now();
+    setNotes([
+      ...notes,
+      {
+        id,
+        content: '',
+        x: 40,
+        y: 40,
+        width: 150,
+        height: 120,
+        archived: false
+      }
+    ]);
+  };
+
+  const updateNote = (id: number, data: Partial<Note>) => {
+    setNotes(notes.map(n => (n.id === id ? { ...n, ...data } : n)));
+  };
+
+  const removeNote = (id: number) => {
+    setNotes(notes.filter(n => n.id !== id));
+  };
+
   return (
     <UserProvider>
       <div className="app">
-        <AccountControls />
-        <NoteCanvas />
+        <AccountControls onAddNote={addNote} />
+        <NoteCanvas
+          notes={notes.filter(n => !n.archived)}
+          onDelete={removeNote}
+          onUpdate={updateNote}
+          onArchive={(id) => updateNote(id, { archived: true })}
+        />
       </div>
     </UserProvider>
   );

--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -1,40 +1,31 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { StickyNote } from './StickyNote';
 import './App.css';
+import { Note } from './App';
 
-interface Note {
-  id: number;
-  text: string;
+export interface NoteCanvasProps {
+  notes: Note[];
+  onDelete: (id: number) => void;
+  onUpdate: (id: number, data: Partial<Note>) => void;
+  onArchive: (id: number) => void;
 }
 
-export const NoteCanvas: React.FC = () => {
-  const [notes, setNotes] = useState<Note[]>([]);
-
-  const addNote = () => {
-    setNotes([...notes, { id: Date.now(), text: '' }]);
-  };
-
-  const removeNote = (id: number) => {
-    setNotes(notes.filter(n => n.id !== id));
-  };
-
-  const updateNote = (id: number, text: string) => {
-    setNotes(notes.map(n => (n.id === id ? { ...n, text } : n)));
-  };
-
+export const NoteCanvas: React.FC<NoteCanvasProps> = ({
+  notes,
+  onDelete,
+  onUpdate,
+  onArchive
+}) => {
   return (
     <div className="board">
-      <div className="controls">
-        <button onClick={addNote}>Add Note</button>
-      </div>
       <div className="notes">
         {notes.map(note => (
           <StickyNote
             key={note.id}
-            id={note.id}
-            text={note.text}
-            onDelete={removeNote}
-            onUpdate={updateNote}
+            note={note}
+            onDelete={onDelete}
+            onUpdate={onUpdate}
+            onArchive={onArchive}
           />
         ))}
       </div>

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -1,25 +1,85 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
+import { Note } from './App';
 
 export interface StickyNoteProps {
-  id: number;
-  text: string;
+  note: Note;
   onDelete: (id: number) => void;
-  onUpdate: (id: number, text: string) => void;
+  onUpdate: (id: number, data: Partial<Note>) => void;
+  onArchive: (id: number) => void;
 }
 
-export const StickyNote: React.FC<StickyNoteProps> = ({ id, text, onDelete, onUpdate }) => {
-  const [value, setValue] = React.useState(text);
+export const StickyNote: React.FC<StickyNoteProps> = ({ note, onDelete, onUpdate, onArchive }) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [selected, setSelected] = useState(false);
+  const modeRef = useRef<'drag' | 'resize' | null>(null);
+  const offsetRef = useRef({ x: 0, y: 0 });
+
+  const pointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    if (target.classList.contains('resize-handle')) {
+      modeRef.current = 'resize';
+    } else if (!target.closest('.toolbar')) {
+      modeRef.current = 'drag';
+      offsetRef.current = { x: e.clientX - note.x, y: e.clientY - note.y };
+    }
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const pointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (modeRef.current === 'drag') {
+      onUpdate(note.id, { x: e.clientX - offsetRef.current.x, y: e.clientY - offsetRef.current.y });
+    }
+    if (modeRef.current === 'resize') {
+      const newWidth = Math.max(80, e.clientX - note.x);
+      const newHeight = Math.max(60, e.clientY - note.y);
+      onUpdate(note.id, { width: newWidth, height: newHeight });
+    }
+  };
+
+  const pointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    modeRef.current = null;
+    (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+  };
+
+  const handleInput = () => {
+    if (contentRef.current) {
+      onUpdate(note.id, { content: contentRef.current.innerHTML });
+    }
+  };
+
+  const exec = (cmd: string) => {
+    document.execCommand(cmd);
+  };
 
   return (
-    <div className="note">
-      <button className="delete" onClick={() => onDelete(id)}>&times;</button>
-      <textarea
+    <div
+      className="note"
+      style={{ left: note.x, top: note.y, width: note.width, height: note.height }}
+      onPointerDown={pointerDown}
+      onPointerMove={pointerMove}
+      onPointerUp={pointerUp}
+      onClick={() => setSelected(true)}
+    >
+      {selected && (
+        <div className="toolbar">
+          <button onMouseDown={e => e.preventDefault()} onClick={() => exec('bold')}>B</button>
+          <button onMouseDown={e => e.preventDefault()} onClick={() => exec('italic')}>I</button>
+          <button onMouseDown={e => e.preventDefault()} onClick={() => exec('underline')}>U</button>
+        </div>
+      )}
+      <button className="delete" onClick={() => onDelete(note.id)}>&times;</button>
+      <button className="archive" onClick={() => onArchive(note.id)} title="Archive">&#128465;</button>
+      <div
+        ref={contentRef}
         className="note-text"
-        value={value}
-        onChange={e => setValue(e.target.value)}
-        onBlur={() => onUpdate(id, value)}
-        placeholder="Write something..."
+        contentEditable
+        suppressContentEditableWarning
+        onInput={handleInput}
+        onFocus={() => setSelected(true)}
+        onBlur={() => setSelected(false)}
+        dangerouslySetInnerHTML={{ __html: note.content }}
       />
+      <div className="resize-handle" />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- move the Add Note button into the header
- keep notes in app state and pass them down
- allow archiving and rich‑text editing of notes
- add drag and resize support for notes
- style toolbar, archive and resize controls

## Testing
- `npm test --workspace packages/frontend`
- `npm run build --workspace packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_68461a10e768832b83f6aaa163c03539