### PR TITLE
Add Markdown editor and modern UI

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sticky Notes App</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p8fYB2vS1AHUqiKHeNeNe2eVarccGqzIDQaROHe2xHtX1u0tAMlSiruIykzoEqx0tYmnLkCtIZ9WmXDYH1ZjKw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,8 +8,10 @@
     "test": "echo 'no tests yet'"
   },
   "dependencies": {
+    "easymde": "^2.20.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-simplemde-editor": "^5.2.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/packages/frontend/src/AccountControls.tsx
+++ b/packages/frontend/src/AccountControls.tsx
@@ -10,7 +10,7 @@ export const AccountControls: React.FC<AccountControlsProps> = ({ onAddNote }) =
 
   return (
     <div className="account">
-      <button className="add-note" onClick={onAddNote}>Add Note</button>
+      <button className="add-note" onClick={onAddNote}><i className="fa fa-plus" /> Add Note</button>
       {user ? (
         <>
           <span className="welcome">Hello, {user.name}</span>

--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -25,28 +25,33 @@
 }
 
 .note {
-  background-color: #fff9c4;
+  background-color: #fff;
+  border: 1px solid #e5e7eb;
   padding: 0.5rem;
   position: absolute;
-  border-radius: 4px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
   word-break: break-word;
   touch-action: none;
+  transition: box-shadow 0.2s ease;
+}
+
+.note:active {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
 }
 
 
 .note-text {
   width: 100%;
   height: 100%;
-  border: none;
-  background: transparent;
-  resize: none;
-  font-family: inherit;
-  font-size: 1rem;
-  outline: none;
 }
 
-.note .delete {
+.note .CodeMirror,
+.note textarea {
+  height: calc(100% - 24px);
+}
+
+.note .archive {
   position: absolute;
   top: 4px;
   right: 4px;
@@ -54,16 +59,7 @@
   background: transparent;
   cursor: pointer;
   font-size: 1rem;
-}
-
-.note .archive {
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  font-size: 1rem;
+  color: #475569;
 }
 
 .resize-handle {
@@ -72,30 +68,8 @@
   bottom: 0;
   width: 16px;
   height: 16px;
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(0, 0, 0, 0.15);
   cursor: nwse-resize;
-}
-
-.toolbar {
-  display: flex;
-  gap: 0.25rem;
-  margin-bottom: 0.25rem;
-}
-
-.toolbar button {
-  padding: 0.25rem;
-  font-size: 0.9rem;
-  background: #f3f4f6;
-  border: 1px solid #e5e7eb;
-  border-radius: 4px;
-  cursor: pointer;
-}
-.toolbar button:active {
-  background: #e5e7eb;
-}
-
-.note .delete:hover {
-  color: #dc2626;
 }
 
 .app {
@@ -121,8 +95,8 @@
   cursor: pointer;
 }
 .account .add-note {
-  background-color: #14b8a6;
-  border-color: #14b8a6;
+  background-color: #3b82f6;
+  border-color: #3b82f6;
 }
 .account button:hover {
   background-color: rgba(255, 255, 255, 0.2);

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -37,9 +37,6 @@ const App: React.FC = () => {
     setNotes(notes.map(n => (n.id === id ? { ...n, ...data } : n)));
   };
 
-  const removeNote = (id: number) => {
-    setNotes(notes.filter(n => n.id !== id));
-  };
 
   return (
     <UserProvider>
@@ -47,7 +44,6 @@ const App: React.FC = () => {
         <AccountControls onAddNote={addNote} />
         <NoteCanvas
           notes={notes.filter(n => !n.archived)}
-          onDelete={removeNote}
           onUpdate={updateNote}
           onArchive={(id) => updateNote(id, { archived: true })}
         />

--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -5,14 +5,12 @@ import { Note } from './App';
 
 export interface NoteCanvasProps {
   notes: Note[];
-  onDelete: (id: number) => void;
   onUpdate: (id: number, data: Partial<Note>) => void;
   onArchive: (id: number) => void;
 }
 
 export const NoteCanvas: React.FC<NoteCanvasProps> = ({
   notes,
-  onDelete,
   onUpdate,
   onArchive
 }) => {
@@ -23,7 +21,6 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
           <StickyNote
             key={note.id}
             note={note}
-            onDelete={onDelete}
             onUpdate={onUpdate}
             onArchive={onArchive}
           />

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -1,16 +1,15 @@
 import React, { useRef, useState } from 'react';
+import SimpleMdeReact from 'react-simplemde-editor';
+import 'easymde/dist/easymde.min.css';
 import { Note } from './App';
 
 export interface StickyNoteProps {
   note: Note;
-  onDelete: (id: number) => void;
   onUpdate: (id: number, data: Partial<Note>) => void;
   onArchive: (id: number) => void;
 }
 
-export const StickyNote: React.FC<StickyNoteProps> = ({ note, onDelete, onUpdate, onArchive }) => {
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [selected, setSelected] = useState(false);
+export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchive }) => {
   const modeRef = useRef<'drag' | 'resize' | null>(null);
   const offsetRef = useRef({ x: 0, y: 0 });
 
@@ -18,7 +17,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onDelete, onUpdate
     const target = e.target as HTMLElement;
     if (target.classList.contains('resize-handle')) {
       modeRef.current = 'resize';
-    } else if (!target.closest('.toolbar')) {
+    } else if (!target.closest('.editor-toolbar')) {
       modeRef.current = 'drag';
       offsetRef.current = { x: e.clientX - note.x, y: e.clientY - note.y };
     }
@@ -41,14 +40,8 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onDelete, onUpdate
     (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
   };
 
-  const handleInput = () => {
-    if (contentRef.current) {
-      onUpdate(note.id, { content: contentRef.current.innerHTML });
-    }
-  };
-
-  const exec = (cmd: string) => {
-    document.execCommand(cmd);
+  const handleChange = (value: string) => {
+    onUpdate(note.id, { content: value });
   };
 
   return (
@@ -58,26 +51,16 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onDelete, onUpdate
       onPointerDown={pointerDown}
       onPointerMove={pointerMove}
       onPointerUp={pointerUp}
-      onClick={() => setSelected(true)}
     >
-      {selected && (
-        <div className="toolbar">
-          <button onMouseDown={e => e.preventDefault()} onClick={() => exec('bold')}>B</button>
-          <button onMouseDown={e => e.preventDefault()} onClick={() => exec('italic')}>I</button>
-          <button onMouseDown={e => e.preventDefault()} onClick={() => exec('underline')}>U</button>
-        </div>
-      )}
-      <button className="delete" onClick={() => onDelete(note.id)}>&times;</button>
-      <button className="archive" onClick={() => onArchive(note.id)} title="Archive">&#128465;</button>
-      <div
-        ref={contentRef}
-        className="note-text"
-        contentEditable
-        suppressContentEditableWarning
-        onInput={handleInput}
-        onFocus={() => setSelected(true)}
-        onBlur={() => setSelected(false)}
-        dangerouslySetInnerHTML={{ __html: note.content }}
+      <button className="archive" onClick={() => onArchive(note.id)} title="Archive"><i className="fa fa-box-archive" /></button>
+      <SimpleMdeReact
+        value={note.content}
+        onChange={handleChange}
+        options={{
+          spellChecker: false,
+          status: false,
+          toolbar: ["bold", "italic", "heading", "|", "quote", "unordered-list", "ordered-list", "|", "link", "preview"],
+        }}
       />
       <div className="resize-handle" />
     </div>

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -1,4 +1,4 @@
 body {
   margin: 0;
-  background-color: #f0f9ff;
+  background-color: #f8fafc;
 }


### PR DESCRIPTION
## Summary
- modernize layout with flat styling and Font Awesome icons
- swap delete button with archive action and embed EasyMDE markdown editor

## Testing
- `npm test --workspace packages/frontend`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68461bd9e4e0832b9f113100d92f15d3