### PR TITLE
Remove markdown editor

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,10 +8,8 @@
     "test": "echo 'no tests yet'"
   },
   "dependencies": {
-    "easymde": "^2.20.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-simplemde-editor": "^5.2.0"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -36,6 +36,10 @@
   transition: box-shadow 0.2s ease;
 }
 
+.note.selected {
+  border-color: #3b82f6;
+}
+
 .note:active {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
 }
@@ -46,9 +50,19 @@
   height: 100%;
 }
 
-.note .CodeMirror,
+.note-content {
+  width: 100%;
+  height: 100%;
+  white-space: pre-wrap;
+  overflow-y: auto;
+}
+
+.note-content.placeholder {
+  color: #94a3b8;
+}
+
 .note textarea {
-  height: calc(100% - 24px);
+  height: 100%;
 }
 
 .note .archive {

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -16,6 +16,7 @@ export interface Note {
 
 const App: React.FC = () => {
   const [notes, setNotes] = useState<Note[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
 
   const addNote = () => {
     const id = Date.now();
@@ -46,6 +47,8 @@ const App: React.FC = () => {
           notes={notes.filter(n => !n.archived)}
           onUpdate={updateNote}
           onArchive={(id) => updateNote(id, { archived: true })}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
         />
       </div>
     </UserProvider>

--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -7,15 +7,19 @@ export interface NoteCanvasProps {
   notes: Note[];
   onUpdate: (id: number, data: Partial<Note>) => void;
   onArchive: (id: number) => void;
+  selectedId: number | null;
+  onSelect: (id: number | null) => void;
 }
 
 export const NoteCanvas: React.FC<NoteCanvasProps> = ({
   notes,
   onUpdate,
-  onArchive
+  onArchive,
+  selectedId,
+  onSelect
 }) => {
   return (
-    <div className="board">
+    <div className="board" onPointerDown={() => onSelect(null)}>
       <div className="notes">
         {notes.map(note => (
           <StickyNote
@@ -23,6 +27,8 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
             note={note}
             onUpdate={onUpdate}
             onArchive={onArchive}
+            selected={selectedId === note.id}
+            onSelect={onSelect}
           />
         ))}
       </div>

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -1,23 +1,26 @@
 import React, { useRef, useState } from 'react';
-import SimpleMdeReact from 'react-simplemde-editor';
-import 'easymde/dist/easymde.min.css';
 import { Note } from './App';
 
 export interface StickyNoteProps {
   note: Note;
   onUpdate: (id: number, data: Partial<Note>) => void;
   onArchive: (id: number) => void;
+  selected: boolean;
+  onSelect: (id: number) => void;
 }
 
-export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchive }) => {
+export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchive, selected, onSelect }) => {
   const modeRef = useRef<'drag' | 'resize' | null>(null);
   const offsetRef = useRef({ x: 0, y: 0 });
+  const [editing, setEditing] = useState(false);
 
   const pointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    onSelect(note.id);
+    if (editing) return;
     const target = e.target as HTMLElement;
     if (target.classList.contains('resize-handle')) {
       modeRef.current = 'resize';
-    } else if (!target.closest('.editor-toolbar')) {
+    } else {
       modeRef.current = 'drag';
       offsetRef.current = { x: e.clientX - note.x, y: e.clientY - note.y };
     }
@@ -25,6 +28,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
   };
 
   const pointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (editing) return;
     if (modeRef.current === 'drag') {
       onUpdate(note.id, { x: e.clientX - offsetRef.current.x, y: e.clientY - offsetRef.current.y });
     }
@@ -46,23 +50,30 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
 
   return (
     <div
-      className="note"
+      className={`note${selected ? ' selected' : ''}`}
       style={{ left: note.x, top: note.y, width: note.width, height: note.height }}
       onPointerDown={pointerDown}
       onPointerMove={pointerMove}
       onPointerUp={pointerUp}
+      onDoubleClick={() => setEditing(true)}
     >
-      <button className="archive" onClick={() => onArchive(note.id)} title="Archive"><i className="fa fa-box-archive" /></button>
-      <SimpleMdeReact
-        value={note.content}
-        onChange={handleChange}
-        options={{
-          spellChecker: false,
-          status: false,
-          toolbar: ["bold", "italic", "heading", "|", "quote", "unordered-list", "ordered-list", "|", "link", "preview"],
-        }}
-      />
-      <div className="resize-handle" />
+      {selected && !editing && (
+        <button className="archive" onClick={() => onArchive(note.id)} title="Archive">
+          <i className="fa fa-box-archive" />
+        </button>
+      )}
+      {editing ? (
+        <textarea
+          className="note-text"
+          value={note.content}
+          onChange={e => handleChange(e.target.value)}
+          onBlur={() => setEditing(false)}
+          autoFocus
+        />
+      ) : (
+        <div className={`note-content${note.content ? '' : ' placeholder'}`}>{note.content || 'Empty Note'}</div>
+      )}
+      {selected && !editing && <div className="resize-handle" />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- swap out markdown editor for plain textarea on sticky notes
- hide actions like archive and resize until a note is selected
- select a note on click and double click to edit

## Testing
- `npm run build --workspace packages/frontend`
- `npm test --workspace packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_68461de7e308832b815c4cd814e2ba1f