### PR TITLE
Fix note selection UI controls

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -77,8 +77,14 @@
   border: none;
   background: transparent;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: 1.25rem;
   color: #475569;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
 }
 
 .rotate-handle {
@@ -88,16 +94,22 @@
   border: none;
   background: transparent;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: 1.25rem;
   color: #475569;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
 }
 
 .color-picker {
   position: absolute;
   bottom: 4px;
   left: 4px;
-  width: 24px;
-  height: 24px;
+  width: 28px;
+  height: 28px;
   padding: 0;
   border: none;
   background: transparent;
@@ -108,8 +120,8 @@
   position: absolute;
   right: 0;
   bottom: 0;
-  width: 16px;
-  height: 16px;
+  width: 24px;
+  height: 24px;
   background: rgba(0, 0, 0, 0.15);
   cursor: nwse-resize;
 }

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -30,6 +30,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
   const [editing, setEditing] = useState(false);
 
   const pointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.stopPropagation();
     onSelect(note.id);
     if (editing) return;
     const target = e.target as HTMLElement;
@@ -82,7 +83,12 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
       onDoubleClick={() => setEditing(true)}
     >
       {selected && !editing && (
-        <button className="archive" onClick={() => onArchive(note.id)} title="Archive">
+        <button
+          className="archive"
+          onPointerDown={e => e.stopPropagation()}
+          onClick={() => onArchive(note.id)}
+          title="Archive"
+        >
           <i className="fa fa-box-archive" />
         </button>
       )}
@@ -90,6 +96,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
         <>
           <button
             className="rotate-handle"
+            onPointerDown={e => e.stopPropagation()}
             onClick={() => onUpdate(note.id, { rotation: note.rotation + 15 })}
             title="Rotate"
           >


### PR DESCRIPTION
## Summary
- fix unselecting notes by stopping event propagation
- prevent dragging when using archive or rotate buttons
- enlarge note controls for better touch support

## Testing
- `npm -ws test`

------
https://chatgpt.com/codex/tasks/task_e_684620bdb86c832b9e0fc9aaf2585a00