### PR TITLE
Add new overlay note controls

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -70,59 +70,67 @@
   height: 100%;
 }
 
-.note .archive {
+.note-controls {
   position: absolute;
-  top: 4px;
-  right: 4px;
+  inset: 0;
+  pointer-events: none;
+}
+
+.note-control {
+  pointer-events: auto;
+  position: absolute;
+  width: 32px;
+  height: 32px;
   border: none;
-  background: transparent;
-  cursor: pointer;
-  font-size: 1.25rem;
-  color: #475569;
-  width: 28px;
-  height: 28px;
+  background: rgba(255, 255, 255, 0.9);
+  color: #1e293b;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.note .archive {
+  top: 4px;
+  right: 4px;
 }
 
 .rotate-handle {
-  position: absolute;
   top: 4px;
   left: 4px;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  font-size: 1.25rem;
-  color: #475569;
-  width: 28px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
 }
 
-.color-picker {
+.color-palette {
   position: absolute;
   bottom: 4px;
   left: 4px;
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border: none;
-  background: transparent;
+  display: flex;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 4px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  pointer-events: auto;
+}
+
+.color-swatch {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid #ffffff;
   cursor: pointer;
 }
 
+.color-swatch.selected {
+  outline: 2px solid #1e293b;
+}
+
 .resize-handle {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  width: 24px;
-  height: 24px;
-  background: rgba(0, 0, 0, 0.15);
+  bottom: 4px;
+  right: 4px;
   cursor: nwse-resize;
 }
 

--- a/packages/frontend/src/ColorPalette.tsx
+++ b/packages/frontend/src/ColorPalette.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export interface ColorPaletteProps {
+  value: string;
+  onChange: (color: string) => void;
+}
+
+export const PALETTE_COLORS = [
+  '#fef08a',
+  '#fdba74',
+  '#fecaca',
+  '#fcd34d',
+  '#86efac',
+  '#93c5fd',
+  '#e9d5ff',
+  '#c7d2fe',
+];
+
+export const ColorPalette: React.FC<ColorPaletteProps> = ({ value, onChange }) => {
+  return (
+    <div className="color-palette" onPointerDown={e => e.stopPropagation()}>
+      {PALETTE_COLORS.map((color) => (
+        <button
+          key={color}
+          className={`color-swatch${color === value ? ' selected' : ''}`}
+          style={{ backgroundColor: color }}
+          title="Change color"
+          onClick={() => onChange(color)}
+        />
+      ))}
+    </div>
+  );
+};

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react';
 import { Note } from './App';
+import { ColorPalette } from './ColorPalette';
 
 const adjustColor = (color: string, amount: number) => {
   let c = color.startsWith('#') ? color.slice(1) : color;
@@ -83,36 +84,31 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
       onDoubleClick={() => setEditing(true)}
     >
       {selected && !editing && (
-        <button
-          className="archive"
-          onPointerDown={e => e.stopPropagation()}
-          onClick={() => onArchive(note.id)}
-          title="Archive"
-        >
-          <i className="fa fa-box-archive" />
-        </button>
-      )}
-      {selected && !editing && (
-        <>
+        <div className="note-controls">
           <button
-            className="rotate-handle"
+            className="archive note-control"
+            onPointerDown={e => e.stopPropagation()}
+            onClick={() => onArchive(note.id)}
+            title="Archive"
+          >
+            <i className="fa fa-box-archive" />
+          </button>
+          <button
+            className="rotate-handle note-control"
             onPointerDown={e => e.stopPropagation()}
             onClick={() => onUpdate(note.id, { rotation: note.rotation + 15 })}
             title="Rotate"
           >
             <i className="fa fa-rotate" />
           </button>
-          <input
-            type="color"
-            className="color-picker"
+          <ColorPalette
             value={note.color}
-            onChange={(e) => onUpdate(note.id, { color: e.target.value })}
-            onPointerDown={(e) => {
-              e.stopPropagation();
-              onSelect(note.id);
-            }}
+            onChange={(color) => onUpdate(note.id, { color })}
           />
-        </>
+          <div className="resize-handle note-control">
+            <i className="fa fa-up-right-and-down-left-from-center" />
+          </div>
+        </div>
       )}
       {editing ? (
         <textarea
@@ -125,7 +121,6 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
       ) : (
         <div className={`note-content${note.content ? '' : ' placeholder'}`}>{note.content || 'Empty Note'}</div>
       )}
-      {selected && !editing && <div className="resize-handle" />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- create `ColorPalette` component with 8 preset colors
- show archive, rotate, color palette and resize icons only when a note is selected
- style new overlay controls for improved visibility

## Testing
- `npm test --workspace packages/frontend`
- `npm run build --workspace packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_6846228fd2a0832bb29623d915579c3d