### PR TITLE
Improve rotate handle UI/UX

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -101,6 +101,12 @@
 .rotate-handle {
   top: 4px;
   left: 4px;
+  background: transparent;
+  box-shadow: none;
+}
+
+.rotate-handle:hover {
+  color: #3b82f6;
 }
 
 .color-palette {


### PR DESCRIPTION
## Summary
- convert rotate button into a draggable rotate handle
- tweak rotate handle styles and hover color

## Testing
- `npm test --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_684625262304832b93fd2110d4b686f8