### PR TITLE
Add collapsible color palette

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -116,6 +116,20 @@
   pointer-events: auto;
 }
 
+.palette-toggle {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+}
+
+.palette-button {
+  border-radius: 50%;
+}
+
+.palette-button:hover {
+  background: #e2e8f0;
+}
+
 .color-swatch {
   width: 20px;
   height: 20px;

--- a/packages/frontend/src/ColorPalette.tsx
+++ b/packages/frontend/src/ColorPalette.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 export interface ColorPaletteProps {
   value: string;
@@ -17,6 +17,23 @@ export const PALETTE_COLORS = [
 ];
 
 export const ColorPalette: React.FC<ColorPaletteProps> = ({ value, onChange }) => {
+  const [open, setOpen] = useState(false);
+
+  if (!open) {
+    return (
+      <div className="palette-toggle">
+        <button
+          className="note-control palette-button"
+          onPointerDown={e => e.stopPropagation()}
+          onClick={() => setOpen(true)}
+          title="Change color"
+        >
+          <i className="fa fa-palette" />
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="color-palette" onPointerDown={e => e.stopPropagation()}>
       {PALETTE_COLORS.map((color) => (
@@ -25,7 +42,10 @@ export const ColorPalette: React.FC<ColorPaletteProps> = ({ value, onChange }) =
           className={`color-swatch${color === value ? ' selected' : ''}`}
           style={{ backgroundColor: color }}
           title="Change color"
-          onClick={() => onChange(color)}
+          onClick={() => {
+            onChange(color);
+            setOpen(false);
+          }}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- toggle color palette open/closed in StickyNote controls
- style palette button with hover highlight

## Testing
- `npm run build`
- `npm test --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_6846255de62c832b9f686bc848b159d7