### PR TITLE
Add hover highlight for archive icon

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -93,6 +93,14 @@
   cursor: pointer;
 }
 
+.note-control:hover {
+  background: #e2e8f0;
+}
+
+.note-control:hover i {
+  color: #3b82f6;
+}
+
 .note .archive {
   top: 4px;
   right: 4px;


### PR DESCRIPTION
## Summary
- add hover styles so the archive button icon stands out

## Testing
- `npm test --workspace packages/frontend`
- `npm test --workspace packages/backend`
- `npm test --workspace packages/shared`


------
https://chatgpt.com/codex/tasks/task_e_68462572af8c832b91c9fc7b9e904231