### PR TITLE
Improve rotate handle UX

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -107,10 +107,15 @@
 }
 
 .rotate-handle {
-  top: 4px;
-  left: 4px;
+  top: -20px;
+  left: -20px;
   background: transparent;
   box-shadow: none;
+  cursor: grab;
+}
+
+.rotate-handle:active {
+  cursor: grabbing;
 }
 
 .rotate-handle:hover {

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -103,7 +103,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
       onDoubleClick={() => setEditing(true)}
     >
       {selected && !editing && (
-        <div className="note-controls">
+        <div className="note-controls" style={{ transform: `rotate(${-note.rotation}deg)` }}>
           <button
             className="archive note-control"
             onPointerDown={e => e.stopPropagation()}


### PR DESCRIPTION
## Summary
- move rotate handle outside the note and change cursor interaction
- keep note controls unrotated so the rotate handle stays under the cursor

## Testing
- `npm test --workspace packages/frontend`
- `npm test --workspace packages/backend`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68462980f050832baa7cf76e9e9c1b6e