### PR TITLE
Fix rotation of note controls

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -33,7 +33,7 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
   word-break: break-word;
   touch-action: none;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  transition: box-shadow 0.2s ease;
 }
 
 .note.selected {
@@ -47,6 +47,7 @@
 .note:hover {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
   transform: scale(1.02);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 


### PR DESCRIPTION
## Summary
- keep note controls aligned when rotating notes by removing transform transitions

## Testing
- `npm test --workspace packages/frontend`
- `npm test --workspace packages/backend`
- `npm test --workspace packages/shared`


------
https://chatgpt.com/codex/tasks/task_e_68462be70b48832ba57cfc4c06d9ff34