### PR TITLE
Remove rotate functionality

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -107,21 +107,6 @@
   right: 4px;
 }
 
-.rotate-handle {
-  top: -20px;
-  left: -20px;
-  background: transparent;
-  box-shadow: none;
-  cursor: grab;
-}
-
-.rotate-handle:active {
-  cursor: grabbing;
-}
-
-.rotate-handle:hover {
-  color: #3b82f6;
-}
 
 .color-palette {
   position: absolute;

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -13,7 +13,6 @@ export interface Note {
   height: number;
   archived: boolean;
   color: string;
-  rotation: number;
   zIndex: number;
 }
 
@@ -37,7 +36,6 @@ const App: React.FC = () => {
         height: 120,
         archived: false,
         color: '#fef08a',
-        rotation: 0,
         zIndex: newZ,
       },
     ]);


### PR DESCRIPTION
## Summary
- remove broken rotate features from sticky notes
- update note interface and styling accordingly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68462d6157d4832b889396206c24ec6f