### PR TITLE
Fix text blocking drag

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -63,6 +63,11 @@
   height: 100%;
   white-space: pre-wrap;
   overflow-y: auto;
+  user-select: none;
+}
+
+.note.editing .note-content {
+  user-select: text;
 }
 
 .note-content.placeholder {

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -86,7 +86,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
 
   return (
     <div
-      className={`note${selected ? ' selected' : ''}`}
+      className={`note${selected ? ' selected' : ''}${editing ? ' editing' : ''}`}
       style={{
         left: note.x,
         top: note.y,


### PR DESCRIPTION
## Summary
- allow dragging across text by ignoring selection when not editing
- mark sticky note editing state in CSS

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68463d792f48832bb2994df5936de19a