### PR TITLE
Add pannable infinite canvas

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -4,6 +4,12 @@
   text-align: left;
   flex: 1;
   overflow: hidden;
+  cursor: grab;
+  touch-action: none;
+}
+
+.board.panning {
+  cursor: grabbing;
 }
 
 .controls {
@@ -21,7 +27,9 @@
 }
 
 .notes {
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -20,6 +20,7 @@ const App: React.FC = () => {
   const [notes, setNotes] = useState<Note[]>([]);
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [zCounter, setZCounter] = useState(0);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
 
   const addNote = () => {
     const id = Date.now();
@@ -30,8 +31,8 @@ const App: React.FC = () => {
       {
         id,
         content: '',
-        x: 40,
-        y: 40,
+        x: -offset.x + 40,
+        y: -offset.y + 40,
         width: 150,
         height: 120,
         archived: false,
@@ -67,6 +68,8 @@ const App: React.FC = () => {
           onArchive={(id) => updateNote(id, { archived: true })}
           selectedId={selectedId}
           onSelect={handleSelect}
+          offset={offset}
+          setOffset={setOffset}
         />
       </div>
     </UserProvider>

--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { StickyNote } from './StickyNote';
 import './App.css';
 import { Note } from './App';
@@ -9,6 +9,8 @@ export interface NoteCanvasProps {
   onArchive: (id: number) => void;
   selectedId: number | null;
   onSelect: (id: number | null) => void;
+  offset: { x: number; y: number };
+  setOffset: (pos: { x: number; y: number }) => void;
 }
 
 export const NoteCanvas: React.FC<NoteCanvasProps> = ({
@@ -16,11 +18,47 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
   onUpdate,
   onArchive,
   selectedId,
-  onSelect
+  onSelect,
+  offset,
+  setOffset
 }) => {
+  const panRef = useRef<{ startX: number; startY: number; startOffsetX: number; startOffsetY: number } | null>(null);
+  const [panning, setPanning] = useState(false);
+
+  const pointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    onSelect(null);
+    panRef.current = {
+      startX: e.clientX,
+      startY: e.clientY,
+      startOffsetX: offset.x,
+      startOffsetY: offset.y,
+    };
+    setPanning(true);
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const pointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!panRef.current) return;
+    const dx = e.clientX - panRef.current.startX;
+    const dy = e.clientY - panRef.current.startY;
+    setOffset({ x: panRef.current.startOffsetX + dx, y: panRef.current.startOffsetY + dy });
+  };
+
+  const pointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    panRef.current = null;
+    setPanning(false);
+    (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+  };
+
   return (
-    <div className="board" onPointerDown={() => onSelect(null)}>
-      <div className="notes">
+    <div
+      className={`board${panning ? ' panning' : ''}`}
+      onPointerDown={pointerDown}
+      onPointerMove={pointerMove}
+      onPointerUp={pointerUp}
+      onPointerCancel={pointerUp}
+    >
+      <div className="notes" style={{ transform: `translate(${offset.x}px, ${offset.y}px)` }}>
         {notes.map(note => (
           <StickyNote
             key={note.id}


### PR DESCRIPTION
## Summary
- make board position absolute and allow grabbing/dragging
- implement panning logic in `NoteCanvas`
- track canvas offset in `App` so new notes appear in view

## Testing
- `npm test --workspace packages/frontend`
- `npm test --workspace packages/backend`
- `npm run build --workspace packages/frontend`
- `npm run build --workspace packages/backend`


------
https://chatgpt.com/codex/tasks/task_e_68463dc9d3e0832b9879993332cbe7f2