### PR TITLE
Add archived note visibility toggle

### DIFF
--- a/packages/frontend/src/AccountControls.tsx
+++ b/packages/frontend/src/AccountControls.tsx
@@ -4,13 +4,16 @@ import './App.css';
 
 export interface AccountControlsProps {
   onAddNote: () => void;
+  showArchived: boolean;
+  onToggleArchived: () => void;
 }
-export const AccountControls: React.FC<AccountControlsProps> = ({ onAddNote }) => {
+export const AccountControls: React.FC<AccountControlsProps> = ({ onAddNote, showArchived, onToggleArchived }) => {
   const { user, login, logout } = useContext(UserContext);
 
   return (
     <div className="account">
       <button className="add-note" onClick={onAddNote}><i className="fa-solid fa-plus" /> Add Note</button>
+      <button onClick={onToggleArchived}>{showArchived ? 'Hide Archived' : 'Show Archived'}</button>
       {user ? (
         <>
           <span className="welcome">Hello, {user.name}</span>

--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -195,3 +195,7 @@
 .welcome {
   margin-right: 0.5rem;
 }
+
+.note.archived {
+  opacity: 0.6;
+}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -20,6 +20,7 @@ const App: React.FC = () => {
   const [notes, setNotes] = useState<Note[]>([]);
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [zCounter, setZCounter] = useState(0);
+  const [showArchived, setShowArchived] = useState(false);
 
   const addNote = () => {
     const id = Date.now();
@@ -45,6 +46,10 @@ const App: React.FC = () => {
     setNotes(notes.map(n => (n.id === id ? { ...n, ...data } : n)));
   };
 
+  const toggleArchive = (id: number) => {
+    setNotes(notes.map(n => (n.id === id ? { ...n, archived: !n.archived } : n)));
+  };
+
   const handleSelect = (id: number | null) => {
     if (id === null) {
       setSelectedId(null);
@@ -56,15 +61,21 @@ const App: React.FC = () => {
     setNotes(notes.map(n => (n.id === id ? { ...n, zIndex: newZ } : n)));
   };
 
+  const toggleShowArchived = () => setShowArchived(!showArchived);
+
 
   return (
     <UserProvider>
       <div className="app">
-        <AccountControls onAddNote={addNote} />
+        <AccountControls
+          onAddNote={addNote}
+          showArchived={showArchived}
+          onToggleArchived={toggleShowArchived}
+        />
         <NoteCanvas
-          notes={notes.filter(n => !n.archived)}
+          notes={showArchived ? notes : notes.filter(n => !n.archived)}
           onUpdate={updateNote}
-          onArchive={(id) => updateNote(id, { archived: true })}
+          onArchive={toggleArchive}
           selectedId={selectedId}
           onSelect={handleSelect}
         />

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -86,7 +86,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
 
   return (
     <div
-      className={`note${selected ? ' selected' : ''}`}
+      className={`note${selected ? ' selected' : ''}${note.archived ? ' archived' : ''}`}
       style={{
         left: note.x,
         top: note.y,
@@ -108,9 +108,9 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
             className="archive note-control"
             onPointerDown={e => e.stopPropagation()}
             onClick={() => onArchive(note.id)}
-            title="Archive"
+            title={note.archived ? 'Unarchive' : 'Archive'}
           >
-          <i className="fa-solid fa-box-archive" />
+          <i className={`fa-solid ${note.archived ? 'fa-box-open' : 'fa-box-archive'}`} />
           </button>
           <ColorPalette
             value={note.color}


### PR DESCRIPTION
## Summary
- add Show/Hide Archived button next to Add Note
- support toggling archived notes in App component
- mark archived notes visually and allow unarchiving

## Testing
- `npm -ws test`

------
https://chatgpt.com/codex/tasks/task_e_68463e59ae24832b95a47720fd3d79c2