### PR TITLE
Add archived notes toggle

### DIFF
--- a/packages/frontend/src/AccountControls.tsx
+++ b/packages/frontend/src/AccountControls.tsx
@@ -4,13 +4,16 @@ import './App.css';
 
 export interface AccountControlsProps {
   onAddNote: () => void;
+  showArchived: boolean;
+  onToggleShowArchived: () => void;
 }
-export const AccountControls: React.FC<AccountControlsProps> = ({ onAddNote }) => {
+export const AccountControls: React.FC<AccountControlsProps> = ({ onAddNote, showArchived, onToggleShowArchived }) => {
   const { user, login, logout } = useContext(UserContext);
 
   return (
     <div className="account">
       <button className="add-note" onClick={onAddNote}><i className="fa-solid fa-plus" /> Add Note</button>
+      <button onClick={onToggleShowArchived}>{showArchived ? 'Hide Archived' : 'Show Archived'}</button>
       {user ? (
         <>
           <span className="welcome">Hello, {user.name}</span>

--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -60,6 +60,10 @@
   transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
+.note.archived {
+  opacity: 0.6;
+}
+
 
 .note-text {
   width: 100%;

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -21,6 +21,7 @@ const App: React.FC = () => {
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [zCounter, setZCounter] = useState(0);
   const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [showArchived, setShowArchived] = useState(false);
 
   const addNote = () => {
     const id = Date.now();
@@ -57,15 +58,23 @@ const App: React.FC = () => {
     setNotes(notes.map(n => (n.id === id ? { ...n, zIndex: newZ } : n)));
   };
 
+  const toggleShowArchived = () => {
+    setShowArchived(prev => !prev);
+  };
+
 
   return (
     <UserProvider>
       <div className="app">
-        <AccountControls onAddNote={addNote} />
+        <AccountControls
+          onAddNote={addNote}
+          showArchived={showArchived}
+          onToggleShowArchived={toggleShowArchived}
+        />
         <NoteCanvas
-          notes={notes.filter(n => !n.archived)}
+          notes={notes.filter(n => showArchived || !n.archived)}
           onUpdate={updateNote}
-          onArchive={(id) => updateNote(id, { archived: true })}
+          onArchive={(id, archived) => updateNote(id, { archived })}
           selectedId={selectedId}
           onSelect={handleSelect}
           offset={offset}

--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -6,7 +6,7 @@ import { Note } from './App';
 export interface NoteCanvasProps {
   notes: Note[];
   onUpdate: (id: number, data: Partial<Note>) => void;
-  onArchive: (id: number) => void;
+  onArchive: (id: number, archived: boolean) => void;
   selectedId: number | null;
   onSelect: (id: number | null) => void;
   offset: { x: number; y: number };

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -20,7 +20,7 @@ const adjustColor = (color: string, amount: number) => {
 export interface StickyNoteProps {
   note: Note;
   onUpdate: (id: number, data: Partial<Note>) => void;
-  onArchive: (id: number) => void;
+  onArchive: (id: number, archived: boolean) => void;
   selected: boolean;
   onSelect: (id: number) => void;
 }
@@ -86,7 +86,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
 
   return (
     <div
-      className={`note${selected ? ' selected' : ''}${editing ? ' editing' : ''}`}
+      className={`note${note.archived ? ' archived' : ''}${selected ? ' selected' : ''}${editing ? ' editing' : ''}`}
       style={{
         left: note.x,
         top: note.y,
@@ -107,10 +107,10 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
           <button
             className="archive note-control"
             onPointerDown={e => e.stopPropagation()}
-            onClick={() => onArchive(note.id)}
-            title="Archive"
+            onClick={() => onArchive(note.id, !note.archived)}
+            title={note.archived ? 'Unarchive' : 'Archive'}
           >
-          <i className="fa-solid fa-box-archive" />
+          <i className={`fa-solid ${note.archived ? 'fa-box-open' : 'fa-box-archive'}`} />
           </button>
           <ColorPalette
             value={note.color}


### PR DESCRIPTION
## Summary
- allow toggling display of archived notes via AccountControls
- show archived notes with faded style
- enable unarchive via note control button

## Testing
- `npm test --workspace packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_68463f404d9c832b8b86f54ff7b33f77