### PR TITLE
Add canvas zoom controls

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -213,3 +213,44 @@
 .welcome {
   margin-right: 0.5rem;
 }
+
+.zoom-controls {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 4px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  pointer-events: none;
+  z-index: 100;
+}
+
+.zoom-controls button,
+.zoom-controls input[type="range"] {
+  pointer-events: auto;
+}
+
+.zoom-controls button {
+  border: none;
+  background: none;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #1e293b;
+  border-radius: 4px;
+}
+
+.zoom-controls button:hover {
+  background: #e2e8f0;
+}
+
+.zoom-slider {
+  width: 100px;
+}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -21,6 +21,7 @@ const App: React.FC = () => {
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [zCounter, setZCounter] = useState(0);
   const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
   const [showArchived, setShowArchived] = useState(false);
 
   const addNote = () => {
@@ -79,6 +80,8 @@ const App: React.FC = () => {
           onSelect={handleSelect}
           offset={offset}
           setOffset={setOffset}
+          zoom={zoom}
+          setZoom={setZoom}
         />
       </div>
     </UserProvider>


### PR DESCRIPTION
## Summary
- add zoom state and pass to canvas
- implement zooming, slider and pinch gestures
- account for zoom when manipulating sticky notes
- style zoom controls

## Testing
- `npm run build --workspace packages/frontend`
- `npm test --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_684641cc3eb0832b971b9fd04f053d98