### PR TITLE
Fix zoom controls center scaling

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -254,3 +254,9 @@
 .zoom-slider {
   width: 100px;
 }
+
+.zoom-percentage {
+  min-width: 40px;
+  text-align: center;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Summary
- tweak canvas zoom controls to zoom relative to center
- show zoom level percentage and update button increments

## Testing
- `npm run build`
- `npm test --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_684643c00144832bb9942e0a91161752