### PR TITLE
Fix zoom origin

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -33,6 +33,7 @@
   left: 0;
   width: 100%;
   height: 100%;
+  transform-origin: top left;
   transition: transform 0.15s ease;
 }
 


### PR DESCRIPTION
## Summary
- stabilize note positions when zooming by pinning transform origin to the top-left of the notes layer

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite/tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846634800d4832b8fec255a505535a9