### PR TITLE
Keep note controls fixed size during zoom

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -33,6 +33,7 @@
   left: 0;
   width: 100%;
   height: 100%;
+  --zoom: 1;
   transform-origin: top left;
   transition: transform 0.15s ease;
 }
@@ -102,8 +103,8 @@
 .note-control {
   pointer-events: auto;
   position: absolute;
-  width: 32px;
-  height: 32px;
+  width: calc(32px / var(--zoom));
+  height: calc(32px / var(--zoom));
   border: none;
   background: rgba(255, 255, 255, 0.9);
   color: #1e293b;
@@ -112,7 +113,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.25rem;
+  font-size: calc(1.25rem / var(--zoom));
   cursor: pointer;
 }
 
@@ -125,19 +126,19 @@
 }
 
 .note .archive {
-  top: 4px;
-  right: 4px;
+  top: calc(4px / var(--zoom));
+  right: calc(4px / var(--zoom));
 }
 
 
 .color-palette {
   position: absolute;
-  bottom: 4px;
-  left: 4px;
+  bottom: calc(4px / var(--zoom));
+  left: calc(4px / var(--zoom));
   display: flex;
-  gap: 4px;
+  gap: calc(4px / var(--zoom));
   background: rgba(255, 255, 255, 0.9);
-  padding: 4px;
+  padding: calc(4px / var(--zoom));
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   pointer-events: auto;
@@ -146,10 +147,10 @@
 
 .palette-toggle {
   position: absolute;
-  bottom: 4px;
-  left: 4px;
-  width: 32px;
-  height: 32px;
+  bottom: calc(4px / var(--zoom));
+  left: calc(4px / var(--zoom));
+  width: calc(32px / var(--zoom));
+  height: calc(32px / var(--zoom));
 }
 
 .palette-button {
@@ -162,20 +163,20 @@
 }
 
 .color-swatch {
-  width: 20px;
-  height: 20px;
+  width: calc(20px / var(--zoom));
+  height: calc(20px / var(--zoom));
   border-radius: 50%;
-  border: 2px solid #ffffff;
+  border: calc(2px / var(--zoom)) solid #ffffff;
   cursor: pointer;
 }
 
 .color-swatch.selected {
-  outline: 2px solid #1e293b;
+  outline: calc(2px / var(--zoom)) solid #1e293b;
 }
 
 .resize-handle {
-  bottom: 4px;
-  right: 4px;
+  bottom: calc(4px / var(--zoom));
+  right: calc(4px / var(--zoom));
   cursor: nwse-resize;
 }
 

--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -230,7 +230,12 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
     >
       <div
         className="notes"
-        style={{ transform: `translate(${offset.x}px, ${offset.y}px) scale(${zoom})` }}
+        style={{
+          transform: `translate(${offset.x}px, ${offset.y}px) scale(${zoom})`,
+          // Expose the current zoom level as a CSS variable so child
+          // elements can adjust their styling based on it.
+          '--zoom': zoom,
+        } as React.CSSProperties}
       >
         {notes.map(note => (
           <StickyNote


### PR DESCRIPTION
## Summary
- inject a `--zoom` CSS variable on the notes container
- compute note-control sizing and spacing using CSS `calc()` to counteract zoom
- ensure controls stay the same size while notes and text scale

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846642951b8832b85f3082aec00f5f9