### PR TITLE
Update sticky note editing style

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -72,6 +72,13 @@
 .note-text {
   width: 100%;
   height: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  resize: none;
+  color: inherit;
+  font: inherit;
+  padding: 0;
 }
 
 .note-content {


### PR DESCRIPTION
## Summary
- make textarea invisible so editing a note doesn't visibly change the sticky note

## Testing
- `npm test --workspace packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_684666762fa0832b8ecd31fb15b27b9b