### PR TITLE
Enable min zoom 10%

### DIFF
--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { StickyNote } from './StickyNote';
 import './App.css';
 import { Note } from './App';
-import { clampZoom, zoomAroundCenter, zoomAroundPoint } from './zoomUtils';
+import { clampZoom, zoomAroundCenter, zoomAroundPoint, MIN_ZOOM, MAX_ZOOM } from './zoomUtils';
 
 export interface NoteCanvasProps {
   notes: Note[];
@@ -257,8 +257,8 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
         <input
           className="zoom-slider"
           type="range"
-          min="0.5"
-          max="3"
+          min={MIN_ZOOM}
+          max={MAX_ZOOM}
           step="0.1"
           value={zoom}
           onChange={e => applyZoom(Number(e.target.value))}

--- a/packages/frontend/src/zoomUtils.ts
+++ b/packages/frontend/src/zoomUtils.ts
@@ -3,10 +3,16 @@ export interface Point {
   y: number;
 }
 
+/** Minimum allowable zoom level */
+export const MIN_ZOOM = 0.1;
+
+/** Maximum allowable zoom level */
+export const MAX_ZOOM = 3;
+
 /**
  * Clamp the zoom level between a minimum and maximum value.
  */
-export const clampZoom = (z: number, min = 0.5, max = 3): number => {
+export const clampZoom = (z: number, min = MIN_ZOOM, max = MAX_ZOOM): number => {
   return Math.max(min, Math.min(max, z));
 };
 


### PR DESCRIPTION
## Summary
- support deeper zoom levels by adding `MIN_ZOOM`/`MAX_ZOOM` constants
- use these zoom limits everywhere in the front‑end

## Testing
- `npm test --workspace packages/frontend`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684668edc344832ba209807d256d8fa6