### PR TITLE
Add workspace support to canvas

### DIFF
--- a/packages/frontend/src/AccountControls.tsx
+++ b/packages/frontend/src/AccountControls.tsx
@@ -2,16 +2,46 @@ import React, { useContext } from 'react';
 import { UserContext } from './UserContext';
 import './App.css';
 
+export interface WorkspaceInfo {
+  id: number;
+  name: string;
+}
+
 export interface AccountControlsProps {
   onAddNote: () => void;
   showArchived: boolean;
   onToggleShowArchived: () => void;
+  workspaces: WorkspaceInfo[];
+  currentWorkspaceId: number;
+  onCreateWorkspace: () => void;
+  onSwitchWorkspace: (id: number) => void;
 }
-export const AccountControls: React.FC<AccountControlsProps> = ({ onAddNote, showArchived, onToggleShowArchived }) => {
+export const AccountControls: React.FC<AccountControlsProps> = ({
+  onAddNote,
+  showArchived,
+  onToggleShowArchived,
+  workspaces,
+  currentWorkspaceId,
+  onCreateWorkspace,
+  onSwitchWorkspace,
+}) => {
   const { user, login, logout } = useContext(UserContext);
 
   return (
     <div className="account">
+      <div className="workspace-controls">
+        <select
+          value={currentWorkspaceId}
+          onChange={e => onSwitchWorkspace(Number(e.target.value))}
+        >
+          {workspaces.map(ws => (
+            <option key={ws.id} value={ws.id}>{ws.name}</option>
+          ))}
+        </select>
+        <button onClick={onCreateWorkspace} title="New Workspace">
+          <i className="fa-solid fa-folder-plus" />
+        </button>
+      </div>
       <button className="add-note" onClick={onAddNote}><i className="fa-solid fa-plus" /> Add Note</button>
       <button onClick={onToggleShowArchived}>{showArchived ? 'Hide Archived' : 'Show Archived'}</button>
       {user ? (

--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -215,6 +215,18 @@
   background-color: #3b82f6;
   border-color: #3b82f6;
 }
+.workspace-controls select {
+  margin-right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  background-color: #1e293b;
+  color: #fff;
+  border: 1px solid #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.workspace-controls button {
+  margin-left: 0;
+}
 .account button:hover {
   background-color: rgba(255, 255, 255, 0.2);
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { UserProvider } from './UserContext';
-import { AccountControls } from './AccountControls';
+import { AccountControls, WorkspaceInfo } from './AccountControls';
 import { NoteCanvas } from './NoteCanvas';
 import './App.css';
 
@@ -16,38 +16,63 @@ export interface Note {
   zIndex: number;
 }
 
+interface Workspace {
+  id: number;
+  name: string;
+  notes: Note[];
+  offset: { x: number; y: number };
+  zoom: number;
+  zCounter: number;
+}
+
 const App: React.FC = () => {
-  const [notes, setNotes] = useState<Note[]>([]);
+  const defaultWorkspace: Workspace = {
+    id: 1,
+    name: 'Default',
+    notes: [],
+    offset: { x: 0, y: 0 },
+    zoom: 1,
+    zCounter: 0,
+  };
+
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([defaultWorkspace]);
+  const [currentWorkspaceId, setCurrentWorkspaceId] = useState<number>(1);
   const [selectedId, setSelectedId] = useState<number | null>(null);
-  const [zCounter, setZCounter] = useState(0);
-  const [offset, setOffset] = useState({ x: 0, y: 0 });
-  const [zoom, setZoom] = useState(1);
   const [showArchived, setShowArchived] = useState(false);
 
+  const currentWsIndex = workspaces.findIndex(w => w.id === currentWorkspaceId);
+  const workspace = workspaces[currentWsIndex];
+
   const addNote = () => {
+    if (!workspace) return;
     const id = Date.now();
-    const newZ = zCounter + 1;
-    setZCounter(newZ);
-    setNotes([
-      ...notes,
-      {
-        id,
-        content: '',
-        // Place the new note near the top-left corner of the visible
-        // viewport regardless of the current zoom level.
-        x: (-offset.x + 40) / zoom,
-        y: (-offset.y + 40) / zoom,
-        width: 150,
-        height: 120,
-        archived: false,
-        color: '#fef08a',
-        zIndex: newZ,
-      },
-    ]);
+    const newZ = workspace.zCounter + 1;
+    const newNote: Note = {
+      id,
+      content: '',
+      x: (-workspace.offset.x + 40) / workspace.zoom,
+      y: (-workspace.offset.y + 40) / workspace.zoom,
+      width: 150,
+      height: 120,
+      archived: false,
+      color: '#fef08a',
+      zIndex: newZ,
+    };
+    setWorkspaces(ws =>
+      ws.map((w, i) =>
+        i === currentWsIndex ? { ...w, notes: [...w.notes, newNote], zCounter: newZ } : w
+      )
+    );
   };
 
   const updateNote = (id: number, data: Partial<Note>) => {
-    setNotes(notes.map(n => (n.id === id ? { ...n, ...data } : n)));
+    setWorkspaces(ws =>
+      ws.map((w, i) =>
+        i === currentWsIndex
+          ? { ...w, notes: w.notes.map(n => (n.id === id ? { ...n, ...data } : n)) }
+          : w
+      )
+    );
   };
 
   const handleSelect = (id: number | null) => {
@@ -55,14 +80,55 @@ const App: React.FC = () => {
       setSelectedId(null);
       return;
     }
-    const newZ = zCounter + 1;
-    setZCounter(newZ);
+    const newZ = workspace.zCounter + 1;
     setSelectedId(id);
-    setNotes(notes.map(n => (n.id === id ? { ...n, zIndex: newZ } : n)));
+    setWorkspaces(ws =>
+      ws.map((w, i) =>
+        i === currentWsIndex
+          ? {
+              ...w,
+              zCounter: newZ,
+              notes: w.notes.map(n => (n.id === id ? { ...n, zIndex: newZ } : n)),
+            }
+          : w
+      )
+    );
   };
 
   const toggleShowArchived = () => {
     setShowArchived(prev => !prev);
+  };
+
+  const setOffset = (pos: { x: number; y: number }) => {
+    setWorkspaces(ws =>
+      ws.map((w, i) => (i === currentWsIndex ? { ...w, offset: pos } : w))
+    );
+  };
+
+  const setZoom = (z: number) => {
+    setWorkspaces(ws =>
+      ws.map((w, i) => (i === currentWsIndex ? { ...w, zoom: z } : w))
+    );
+  };
+
+  const createWorkspace = () => {
+    const id = Date.now();
+    const newWs: Workspace = {
+      id,
+      name: `Workspace ${workspaces.length + 1}`,
+      notes: [],
+      offset: { x: 0, y: 0 },
+      zoom: 1,
+      zCounter: 0,
+    };
+    setWorkspaces(ws => [...ws, newWs]);
+    setCurrentWorkspaceId(id);
+    setSelectedId(null);
+  };
+
+  const switchWorkspace = (id: number) => {
+    setCurrentWorkspaceId(id);
+    setSelectedId(null);
   };
 
 
@@ -73,16 +139,20 @@ const App: React.FC = () => {
           onAddNote={addNote}
           showArchived={showArchived}
           onToggleShowArchived={toggleShowArchived}
+          workspaces={workspaces.map(w => ({ id: w.id, name: w.name }))}
+          currentWorkspaceId={currentWorkspaceId}
+          onCreateWorkspace={createWorkspace}
+          onSwitchWorkspace={switchWorkspace}
         />
         <NoteCanvas
-          notes={notes.filter(n => showArchived || !n.archived)}
+          notes={workspace.notes.filter(n => showArchived || !n.archived)}
           onUpdate={updateNote}
           onArchive={(id, archived) => updateNote(id, { archived })}
           selectedId={selectedId}
           onSelect={handleSelect}
-          offset={offset}
+          offset={workspace.offset}
           setOffset={setOffset}
-          zoom={zoom}
+          zoom={workspace.zoom}
           setZoom={setZoom}
         />
       </div>


### PR DESCRIPTION
## Summary
- introduce `Workspace` model to keep notes, zoom and offset per canvas
- add workspace dropdown and create button to the header controls
- style new workspace UI

## Testing
- `npm test --workspaces`
- `npm run build --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_68466cb996a0832b9ca9f0021eaafa3a