### PR TITLE
Improve workspace controls and header

### DIFF
--- a/packages/frontend/src/AccountControls.tsx
+++ b/packages/frontend/src/AccountControls.tsx
@@ -15,6 +15,7 @@ export interface AccountControlsProps {
   currentWorkspaceId: number;
   onCreateWorkspace: () => void;
   onSwitchWorkspace: (id: number) => void;
+  onRenameWorkspace: (id: number) => void;
 }
 export const AccountControls: React.FC<AccountControlsProps> = ({
   onAddNote,
@@ -24,6 +25,7 @@ export const AccountControls: React.FC<AccountControlsProps> = ({
   currentWorkspaceId,
   onCreateWorkspace,
   onSwitchWorkspace,
+  onRenameWorkspace,
 }) => {
   const { user, login, logout } = useContext(UserContext);
 
@@ -41,17 +43,26 @@ export const AccountControls: React.FC<AccountControlsProps> = ({
         <button onClick={onCreateWorkspace} title="New Workspace">
           <i className="fa-solid fa-folder-plus" />
         </button>
+        <button
+          onClick={() => onRenameWorkspace(currentWorkspaceId)}
+          title="Rename Workspace"
+          disabled={currentWorkspaceId === 1}
+        >
+          <i className="fa-solid fa-pen" />
+        </button>
       </div>
-      <button className="add-note" onClick={onAddNote}><i className="fa-solid fa-plus" /> Add Note</button>
-      <button onClick={onToggleShowArchived}>{showArchived ? 'Hide Archived' : 'Show Archived'}</button>
-      {user ? (
-        <>
-          <span className="welcome">Hello, {user.name}</span>
-          <button onClick={logout}>Logout</button>
-        </>
-      ) : (
-        <button onClick={login}>Login</button>
-      )}
+      <div className="account-actions">
+        <button className="add-note" onClick={onAddNote}><i className="fa-solid fa-plus" /> Add Note</button>
+        <button onClick={onToggleShowArchived}>{showArchived ? 'Hide Archived' : 'Show Archived'}</button>
+        {user ? (
+          <>
+            <span className="welcome">Hello, {user.name}</span>
+            <button onClick={logout}>Logout</button>
+          </>
+        ) : (
+          <button onClick={login}>Login</button>
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -195,20 +195,21 @@
 
 .account {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 1rem;
+  padding: 1rem 1.5rem;
   background-color: #0f172a;
   color: #fff;
 }
 
 .account button {
   margin-left: 0.5rem;
-  padding: 0.25rem 0.5rem;
+  padding: 0.5rem 0.75rem;
   background: transparent;
   color: #fff;
   border: 1px solid #fff;
   border-radius: 4px;
+  font-size: 1rem;
   cursor: pointer;
 }
 .account .add-note {
@@ -217,15 +218,22 @@
 }
 .workspace-controls select {
   margin-right: 0.5rem;
-  padding: 0.25rem 0.5rem;
+  padding: 0.5rem 0.75rem;
   background-color: #1e293b;
   color: #fff;
   border: 1px solid #fff;
   border-radius: 4px;
+  font-size: 1rem;
   cursor: pointer;
 }
 .workspace-controls button {
   margin-left: 0;
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+}
+.account-actions {
+  display: flex;
+  align-items: center;
 }
 .account button:hover {
   background-color: rgba(255, 255, 255, 0.2);

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -126,6 +126,17 @@ const App: React.FC = () => {
     setSelectedId(null);
   };
 
+  const renameWorkspace = (id: number) => {
+    const wsIndex = workspaces.findIndex(w => w.id === id);
+    const ws = workspaces[wsIndex];
+    if (!ws || ws.id === 1) return;
+    const name = window.prompt('Workspace name', ws.name);
+    if (!name || name.trim() === '') return;
+    setWorkspaces(all =>
+      all.map((w, i) => (i === wsIndex ? { ...w, name: name.trim() } : w))
+    );
+  };
+
   const switchWorkspace = (id: number) => {
     setCurrentWorkspaceId(id);
     setSelectedId(null);
@@ -143,6 +154,7 @@ const App: React.FC = () => {
           currentWorkspaceId={currentWorkspaceId}
           onCreateWorkspace={createWorkspace}
           onSwitchWorkspace={switchWorkspace}
+          onRenameWorkspace={renameWorkspace}
         />
         <NoteCanvas
           notes={workspace.notes.filter(n => showArchived || !n.archived)}


### PR DESCRIPTION
## Summary
- move workspace controls to the left
- add rename workspace capability
- enlarge header elements for touch devices

## Testing
- `npm run build --workspace packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_68466e731f9c832ba1c2a0a648560f48