### PR TITLE
Fix NoteCanvas zoom offset handling

### DIFF
--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -69,7 +69,9 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
     if (!board) return;
     const clamped = clampZoom(newZoom);
     setZoom(clamped);
-    setOffset(o => zoomAroundCenter(board, zoomRef.current, clamped, o));
+    setOffset(
+      zoomAroundCenter(board, zoomRef.current, clamped, offsetRef.current)
+    );
     zoomRef.current = clamped;
   };
 


### PR DESCRIPTION
## Summary
- fix NoteCanvas.applyZoom to compute offset correctly

## Testing
- `npm test --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_6846725d0128832b925dc8c669ecebd7