### PR TITLE
Fix zoom from center

### DIFF
--- a/packages/frontend/src/zoomUtils.ts
+++ b/packages/frontend/src/zoomUtils.ts
@@ -48,7 +48,9 @@ export const zoomAroundCenter = (
   offset: Point
 ): Point => {
   const rect = board.getBoundingClientRect();
-  const dx = (rect.width / 2) * (1 / nextZoom - 1 / prevZoom);
-  const dy = (rect.height / 2) * (1 / nextZoom - 1 / prevZoom);
-  return { x: offset.x + dx, y: offset.y + dy };
+  const pivot = {
+    x: rect.left + rect.width / 2,
+    y: rect.top + rect.height / 2,
+  };
+  return zoomAroundPoint(board, pivot, prevZoom, nextZoom, offset);
 };


### PR DESCRIPTION
## Summary
- ensure zoom slider/buttons scale around the board's visible center

## Testing
- `npm test --workspace packages/frontend`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684674dbfbbc832b8741a3ad405692e7