### PR TITLE
Improve note dragging overlay

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -104,6 +104,14 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
+  z-index: 2;
+}
+
+.note-drag-target {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.01);
+  z-index: 1;
 }
 
 .note-control {

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -143,7 +143,9 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
       onPointerUp={pointerUp}
       onPointerCancel={pointerCancel}
       onDoubleClick={() => setEditing(true)}
+      draggable={false}
     >
+      {!editing && <div className="note-drag-target" draggable={false} onDragStart={e => e.preventDefault()} />}
       {selected && !editing && (
         // Buttons shown when the note is selected
         <div className="note-controls">


### PR DESCRIPTION
## Summary
- ensure notes are not draggable by the browser
- add transparent overlay for note drag target
- keep note controls above the drag target

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68472e4fecac832b83e290a1fc50e9ab