### PR TITLE
Add send-to-back button for notes

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -144,6 +144,11 @@
   right: calc(4px / var(--zoom));
 }
 
+.note .send-back {
+  top: calc(4px / var(--zoom));
+  right: calc(40px / var(--zoom));
+}
+
 
 .color-palette {
   position: absolute;

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -25,6 +25,10 @@ const App: React.FC = () => {
     appService.updateNote(id, data);
   };
 
+  const sendNoteToBack = (id: number) => {
+    appService.sendNoteToBack(id);
+  };
+
   const handleSelect = (id: number | null) => {
     if (id === null) {
       setSelectedId(null);
@@ -82,6 +86,7 @@ const App: React.FC = () => {
           notes={workspace.notes.filter(n => showArchived || !n.archived)}
           onUpdate={updateNote}
           onArchive={(id, archived) => appService.archiveNote(id, archived)}
+          onSendToBack={sendNoteToBack}
           selectedId={selectedId}
           onSelect={handleSelect}
           offset={workspace.canvas.offset}

--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -14,6 +14,8 @@ export interface NoteCanvasProps {
   onUpdate: (id: number, data: Partial<Note>) => void;
   /** Archive/unarchive a note */
   onArchive: (id: number, archived: boolean) => void;
+  /** Send a note behind all others */
+  onSendToBack: (id: number) => void;
   /** Id of the currently selected note */
   selectedId: number | null;
   /** Select a note or clear the selection */
@@ -32,6 +34,7 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
   notes,
   onUpdate,
   onArchive,
+  onSendToBack,
   selectedId,
   onSelect,
   offset,
@@ -283,6 +286,7 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
             note={note}
             onUpdate={onUpdate}
             onArchive={onArchive}
+            onSendToBack={onSendToBack}
             selected={selectedId === note.id}
             onSelect={onSelect}
             offset={offset}

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -32,13 +32,15 @@ export interface StickyNoteProps {
   selected: boolean;
   /** Select this note */
   onSelect: (id: number) => void;
+  /** Send this note behind all others */
+  onSendToBack: (id: number) => void;
   /** Board offset used to translate screen to board coordinates */
   offset: { x: number; y: number };
   /** Current zoom level of the board */
   zoom: number;
 }
 
-export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchive, selected, onSelect, offset, zoom }) => {
+export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchive, selected, onSelect, onSendToBack, offset, zoom }) => {
   // Track the current interaction mode (dragging vs resizing) and store
   // temporary data needed to calculate positions during the gesture.
   const modeRef = useRef<'drag' | 'resize' | null>(null);
@@ -149,6 +151,14 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
       {selected && !editing && (
         // Buttons shown when the note is selected
         <div className="note-controls">
+          <button
+            className="send-back note-control"
+            onPointerDown={e => e.stopPropagation()}
+            onClick={() => onSendToBack(note.id)}
+            title="Send to Back"
+          >
+            <i className="fa-solid fa-layer-group" />
+          </button>
           <button
             className="archive note-control"
             onPointerDown={e => e.stopPropagation()}

--- a/packages/frontend/src/services/AppService.ts
+++ b/packages/frontend/src/services/AppService.ts
@@ -187,6 +187,16 @@ export class AppService extends EventEmitter {
     this.emitChange();
   }
 
+  /** Move a note to the back of the z-order */
+  sendNoteToBack(id: number): void {
+    const ws = this.currentWorkspace;
+    const note = ws.notes.find(n => n.id === id);
+    if (!note) return;
+    const minZ = Math.min(...ws.notes.map(n => n.zIndex));
+    note.zIndex = minZ - 1;
+    this.emitChange();
+  }
+
   /** Archive or unarchive a note */
   archiveNote(id: number, archived: boolean): void {
     this.updateNote(id, { archived });


### PR DESCRIPTION
## Summary
- add ability to push a note behind others
- show a new "send to back" control on each note

## Testing
- `npm run build --workspace packages/frontend`
- `npm test --workspace packages/frontend`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6847404630e0832b93930f3b09c0ab01