### PR TITLE
Add pin-to-back feature for notes

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -144,9 +144,17 @@
   right: calc(4px / var(--zoom));
 }
 
-.note .send-back {
+.note .pin-back {
   top: calc(4px / var(--zoom));
   right: calc(40px / var(--zoom));
+}
+
+.note-control.active {
+  background: #e2e8f0;
+}
+
+.note-control.active i {
+  color: #3b82f6;
 }
 
 

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -25,8 +25,8 @@ const App: React.FC = () => {
     appService.updateNote(id, data);
   };
 
-  const sendNoteToBack = (id: number) => {
-    appService.sendNoteToBack(id);
+  const setNotePinned = (id: number, pinned: boolean) => {
+    appService.setNotePinned(id, pinned);
   };
 
   const handleSelect = (id: number | null) => {
@@ -35,7 +35,10 @@ const App: React.FC = () => {
       return;
     }
     setSelectedId(id);
-    appService.bringNoteToFront(id);
+    const note = workspace.notes.find(n => n.id === id);
+    if (note && !note.pinned) {
+      appService.bringNoteToFront(id);
+    }
   };
 
   const toggleShowArchived = () => {
@@ -86,7 +89,7 @@ const App: React.FC = () => {
           notes={workspace.notes.filter(n => showArchived || !n.archived)}
           onUpdate={updateNote}
           onArchive={(id, archived) => appService.archiveNote(id, archived)}
-          onSendToBack={sendNoteToBack}
+          onSetPinned={setNotePinned}
           selectedId={selectedId}
           onSelect={handleSelect}
           offset={workspace.canvas.offset}

--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -14,8 +14,8 @@ export interface NoteCanvasProps {
   onUpdate: (id: number, data: Partial<Note>) => void;
   /** Archive/unarchive a note */
   onArchive: (id: number, archived: boolean) => void;
-  /** Send a note behind all others */
-  onSendToBack: (id: number) => void;
+  /** Pin or unpin a note behind all others */
+  onSetPinned: (id: number, pinned: boolean) => void;
   /** Id of the currently selected note */
   selectedId: number | null;
   /** Select a note or clear the selection */
@@ -34,7 +34,7 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
   notes,
   onUpdate,
   onArchive,
-  onSendToBack,
+  onSetPinned,
   selectedId,
   onSelect,
   offset,
@@ -286,7 +286,7 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
             note={note}
             onUpdate={onUpdate}
             onArchive={onArchive}
-            onSendToBack={onSendToBack}
+            onSetPinned={onSetPinned}
             selected={selectedId === note.id}
             onSelect={onSelect}
             offset={offset}

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -32,15 +32,15 @@ export interface StickyNoteProps {
   selected: boolean;
   /** Select this note */
   onSelect: (id: number) => void;
-  /** Send this note behind all others */
-  onSendToBack: (id: number) => void;
+  /** Pin or unpin this note behind all others */
+  onSetPinned: (id: number, pinned: boolean) => void;
   /** Board offset used to translate screen to board coordinates */
   offset: { x: number; y: number };
   /** Current zoom level of the board */
   zoom: number;
 }
 
-export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchive, selected, onSelect, onSendToBack, offset, zoom }) => {
+export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchive, selected, onSelect, onSetPinned, offset, zoom }) => {
   // Track the current interaction mode (dragging vs resizing) and store
   // temporary data needed to calculate positions during the gesture.
   const modeRef = useRef<'drag' | 'resize' | null>(null);
@@ -152,12 +152,12 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
         // Buttons shown when the note is selected
         <div className="note-controls">
           <button
-            className="send-back note-control"
+            className={`pin-back note-control${note.pinned ? ' active' : ''}`}
             onPointerDown={e => e.stopPropagation()}
-            onClick={() => onSendToBack(note.id)}
-            title="Send to Back"
+            onClick={() => onSetPinned(note.id, !note.pinned)}
+            title={note.pinned ? 'Unpin from Back' : 'Pin to Back'}
           >
-            <i className="fa-solid fa-layer-group" />
+            <i className="fa-solid fa-thumbtack" />
           </button>
           <button
             className="archive note-control"

--- a/packages/frontend/src/services/AppService.ts
+++ b/packages/frontend/src/services/AppService.ts
@@ -17,6 +17,7 @@ export interface Note {
   archived: boolean;
   color: string;
   zIndex: number;
+  pinned?: boolean;
 }
 
 /** Canvas state for a workspace */
@@ -157,6 +158,7 @@ export class AppService extends EventEmitter {
       archived: false,
       color: '#fef08a',
       zIndex: newZ,
+      pinned: false,
     };
     ws.canvas.zCounter = newZ;
     ws.notes.push(note);
@@ -195,6 +197,21 @@ export class AppService extends EventEmitter {
     const minZ = Math.min(...ws.notes.map(n => n.zIndex));
     note.zIndex = minZ - 1;
     this.emitChange();
+  }
+
+  /** Pin or unpin a note behind others */
+  setNotePinned(id: number, pinned: boolean): void {
+    const ws = this.currentWorkspace;
+    const note = ws.notes.find(n => n.id === id);
+    if (!note) return;
+    note.pinned = pinned;
+    if (pinned) {
+      const minZ = Math.min(...ws.notes.map(n => n.zIndex));
+      note.zIndex = minZ - 1;
+      this.emitChange();
+    } else {
+      this.bringNoteToFront(id);
+    }
   }
 
   /** Archive or unarchive a note */


### PR DESCRIPTION
## Summary
- allow notes to be pinned behind others
- keep pinned notes from moving forward when selected
- update sticky note controls and styles

## Testing
- `npm run build --workspaces`
- `npm test --workspace packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_68474278d438832b82e237adeeb06868