### PR TITLE
Add floating toolbar for note controls

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -107,6 +107,19 @@
   z-index: 2;
 }
 
+.note-toolbar {
+  position: absolute;
+  top: calc(4px / var(--zoom));
+  right: calc(4px / var(--zoom));
+  display: flex;
+  gap: calc(4px / var(--zoom));
+  pointer-events: auto;
+  background: rgba(255, 255, 255, 0.9);
+  padding: calc(4px / var(--zoom));
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
 .note-drag-target {
   position: absolute;
   inset: 0;
@@ -140,13 +153,11 @@
 }
 
 .note .archive {
-  top: calc(4px / var(--zoom));
-  right: calc(4px / var(--zoom));
+  /* positioning handled by toolbar container */
 }
 
 .note .pin-back {
-  top: calc(4px / var(--zoom));
-  right: calc(40px / var(--zoom));
+  /* positioning handled by toolbar container */
 }
 
 .note-control.active {
@@ -159,9 +170,7 @@
 
 
 .color-palette {
-  position: absolute;
-  bottom: calc(4px / var(--zoom));
-  left: calc(4px / var(--zoom));
+  position: relative;
   display: flex;
   gap: calc(4px / var(--zoom));
   background: rgba(255, 255, 255, 0.9);
@@ -173,9 +182,7 @@
 }
 
 .palette-toggle {
-  position: absolute;
-  bottom: calc(4px / var(--zoom));
-  left: calc(4px / var(--zoom));
+  position: relative;
   width: calc(32px / var(--zoom));
   height: calc(32px / var(--zoom));
 }

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -151,27 +151,29 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
       {selected && !editing && (
         // Buttons shown when the note is selected
         <div className="note-controls">
-          <button
-            className={`pin-back note-control${note.pinned ? ' active' : ''}`}
-            onPointerDown={e => e.stopPropagation()}
-            onClick={() => onSetPinned(note.id, !note.pinned)}
-            title={note.pinned ? 'Unpin from Back' : 'Pin to Back'}
-          >
-            <i className="fa-solid fa-thumbtack" />
-          </button>
-          <button
-            className="archive note-control"
-            onPointerDown={e => e.stopPropagation()}
-            onClick={() => onArchive(note.id, !note.archived)}
-            title={note.archived ? 'Unarchive' : 'Archive'}
-          >
-          <i className={`fa-solid ${note.archived ? 'fa-box-open' : 'fa-box-archive'}`} />
-          </button>
-          {/* Palette for picking a different background color */}
-          <ColorPalette
-            value={note.color}
-            onChange={(color) => onUpdate(note.id, { color })}
-          />
+          <div className="note-toolbar">
+            <button
+              className={`pin-back note-control${note.pinned ? ' active' : ''}`}
+              onPointerDown={e => e.stopPropagation()}
+              onClick={() => onSetPinned(note.id, !note.pinned)}
+              title={note.pinned ? 'Unpin from Back' : 'Pin to Back'}
+            >
+              <i className="fa-solid fa-thumbtack" />
+            </button>
+            {/* Palette for picking a different background color */}
+            <ColorPalette
+              value={note.color}
+              onChange={(color) => onUpdate(note.id, { color })}
+            />
+            <button
+              className="archive note-control"
+              onPointerDown={e => e.stopPropagation()}
+              onClick={() => onArchive(note.id, !note.archived)}
+              title={note.archived ? 'Unarchive' : 'Archive'}
+            >
+              <i className={`fa-solid ${note.archived ? 'fa-box-open' : 'fa-box-archive'}`} />
+            </button>
+          </div>
           {/* Drag handle used for resizing */}
           <div className="resize-handle note-control">
             <i className="fa-solid fa-up-right-and-down-left-from-center" />


### PR DESCRIPTION
## Summary
- create a `note-toolbar` that floats in the top-right corner of a note
- move pin, color, and archive controls into the toolbar
- keep the resize handle in its original position

## Testing
- `npm test --workspace packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_684747119a38832ba7f6268ac1a28232