### PR TITLE
Ensure note controls stay above notes

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -37,6 +37,17 @@
   transform-origin: top left;
 }
 
+.note-overlays {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  transform-origin: top left;
+  z-index: 100;
+}
+
 .note {
   background-color: #fff;
   border: 1px solid #e5e7eb;
@@ -102,9 +113,12 @@
 
 .note-controls {
   position: absolute;
-  inset: 0;
   pointer-events: none;
   z-index: 2;
+}
+
+.note > .note-controls {
+  inset: 0;
 }
 
 .note-toolbar {

--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -58,6 +58,9 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
   const offsetRef = useRef(offset);
   const [mousePos, setMousePos] = useState<{x: number; y: number} | null>(null);
 
+  // Container used to render note controls above all notes
+  const overlayRef = useRef<HTMLDivElement>(null);
+
   // Utility to translate screen coordinates to board coordinates based on the
   // current zoom and pan offset.
   const toBoardCoords = (clientX: number, clientY: number) => {
@@ -291,9 +294,18 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
             onSelect={onSelect}
             offset={offset}
             zoom={zoom}
+            overlayContainer={overlayRef.current}
           />
         ))}
       </div>
+      <div
+        ref={overlayRef}
+        className="note-overlays"
+        style={{
+          transform: `translate(${offset.x}px, ${offset.y}px) scale(${zoom})`,
+          '--zoom': zoom,
+        } as React.CSSProperties}
+      />
       {/* Overlay with buttons and slider to control zoom */}
       <div className="zoom-controls" onPointerDown={e => e.stopPropagation()}>
         <button onClick={() => applyZoom(zoomRef.current * 0.9)} title="Zoom Out">


### PR DESCRIPTION
## Summary
- render note control overlays in a dedicated container so they appear above pinned notes
- add overlay styles and adjust note control positioning

## Testing
- `npm run build --workspace packages/frontend`
- `npm run test --workspace packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_6847524f58e0832bb733ab8da652cc04