### PR TITLE
Fix note resize control overlay

### DIFF
--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -170,7 +170,17 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
       createPortal(
         <div
           className="note-controls"
-          style={{ left: note.x, top: note.y, width: note.width, height: note.height }}
+          style={{
+            left: note.x,
+            top: note.y,
+            width: note.width,
+            height: note.height,
+            pointerEvents: 'auto',
+          }}
+          onPointerDown={pointerDown}
+          onPointerMove={pointerMove}
+          onPointerUp={pointerUp}
+          onPointerCancel={pointerCancel}
         >
           <div className="note-toolbar">
             <button


### PR DESCRIPTION
## Summary
- ensure note overlays respond to pointer events
- hook resize and drag events to overlay control container

## Testing
- `npm test --workspace packages/frontend`
- `npm test --workspace packages/backend`


------
https://chatgpt.com/codex/tasks/task_e_6847549cc5a4832b88ca973a7b7f5671