### PR TITLE
Fix resize handle and restore editing

### DIFF
--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -175,12 +175,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
             top: note.y,
             width: note.width,
             height: note.height,
-            pointerEvents: 'auto',
           }}
-          onPointerDown={pointerDown}
-          onPointerMove={pointerMove}
-          onPointerUp={pointerUp}
-          onPointerCancel={pointerCancel}
         >
           <div className="note-toolbar">
             <button
@@ -204,7 +199,13 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
               <i className={`fa-solid ${note.archived ? 'fa-box-open' : 'fa-box-archive'}`} />
             </button>
           </div>
-          <div className="resize-handle note-control">
+          <div
+            className="resize-handle note-control"
+            onPointerDown={pointerDown}
+            onPointerMove={pointerMove}
+            onPointerUp={pointerUp}
+            onPointerCancel={pointerCancel}
+          >
             <i className="fa-solid fa-up-right-and-down-left-from-center" />
           </div>
         </div>,


### PR DESCRIPTION
## Summary
- ensure double click editing works by letting pointer events through overlay
- attach resize handlers directly to the handle so dragging/resizing still works

## Testing
- `npm run build` in `packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_684756d29178832b89f4ee2e3374eafa