### PR TITLE
Fix overlay size for note controls

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -52,6 +52,7 @@
   background-color: #fff;
   border: 1px solid #e5e7eb;
   padding: 0.5rem;
+  box-sizing: border-box;
   position: absolute;
   border-radius: 6px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
@@ -114,6 +115,7 @@
 .note-controls {
   position: absolute;
   pointer-events: none;
+  box-sizing: border-box;
   z-index: 2;
 }
 


### PR DESCRIPTION
## Summary
- ensure note and note-control overlays use `border-box` sizing so their dimensions match

## Testing
- `npm test --workspace packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_684759af9aa4832bb569a60c378ccee4