### PR TITLE
Add fade effect to resize handle

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -238,6 +238,12 @@
   bottom: calc(4px / var(--zoom));
   right: calc(4px / var(--zoom));
   cursor: nwse-resize;
+  opacity: 0.5;
+  transition: opacity 0.2s ease;
+}
+
+.resize-handle:hover {
+  opacity: 1;
 }
 
 .app {


### PR DESCRIPTION
## Summary
- reduce opacity of resize handle when not hovered
- fade the handle's opacity on hover

## Testing
- `npm test --workspaces`

------
https://chatgpt.com/codex/tasks/task_e_68479ddbf198832b8538977db1d7b436