### PR TITLE
Fix Terraform S3 bucket website warning

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -16,10 +16,17 @@ resource "aws_s3_bucket" "frontend" {
   bucket = var.bucket_name
 
   force_destroy = true
+}
 
-  website {
-    index_document = "index.html"
-    error_document = "index.html"
+resource "aws_s3_bucket_website_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "index.html"
   }
 }
 


### PR DESCRIPTION
## Summary
- fix deprecation by moving website settings to `aws_s3_bucket_website_configuration`

## Testing
- `npm test --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_6847aa70f9b4832b8e22d81153d4e993