### PR TITLE
Fix Terraform bucket policy and CloudFront

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -47,12 +47,12 @@ resource "aws_s3_bucket_policy" "frontend" {
 data "aws_iam_policy_document" "frontend" {
   statement {
     effect = "Allow"
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-    actions = ["s3:GetObject"]
+    actions   = ["s3:GetObject"]
     resources = ["${aws_s3_bucket.frontend.arn}/*"]
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.oai.iam_arn]
+    }
   }
 }
 
@@ -79,6 +79,12 @@ resource "aws_cloudfront_distribution" "frontend" {
     target_origin_id = "frontend-s3"
 
     viewer_protocol_policy = "redirect-to-https"
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
   }
 
   restrictions {


### PR DESCRIPTION
## Summary
- restrict S3 bucket access to CloudFront origin access identity
- add required `forwarded_values` to CloudFront cache behavior

## Testing
- `npm test` *(fails: missing script)*
- `terraform fmt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ab962e7c832b95c46a43bca875da