### PR TITLE
Add ACM certificate variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ distribution.
    ```
 2. Apply the configuration, providing a unique S3 bucket name and AWS region:
    ```bash
-   terraform apply -var="bucket_name=<your-bucket>" -var="aws_region=<region>"
+   terraform apply -var="bucket_name=<your-bucket>" -var="aws_region=<region>" \
+     -var="acm_certificate_arn=<certificate-arn>"
    ```
    Terraform will output the CloudFront distribution ID which is required for
    frontend deployments.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -73,6 +73,8 @@ resource "aws_cloudfront_distribution" "frontend" {
   enabled             = true
   default_root_object = "index.html"
 
+  aliases = [var.domain_name]
+
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD"]
@@ -94,7 +96,8 @@ resource "aws_cloudfront_distribution" "frontend" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    acm_certificate_arn = var.acm_certificate_arn
+    ssl_support_method  = "sni-only"
   }
 }
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -19,3 +19,8 @@ variable "domain_name_root" {
   type        = string
   default     = "thalman.org"
 }
+
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN for CloudFront"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- allow passing an ACM cert to CloudFront
- document the new Terraform variable

## Testing
- `~/.local/bin/aws sts get-caller-identity` *(fails: Unable to locate credentials)*

------
https://chatgpt.com/codex/tasks/task_e_6847b27adf14832b8b7104093faca715