### PR TITLE
Improve modal appearance and add keyboard shortcuts

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -372,3 +372,31 @@
   margin-top: 1rem;
   text-align: right;
 }
+
+.modal-button {
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  border: none;
+  margin-left: 0.5rem;
+}
+
+.modal-button.cancel {
+  background: transparent;
+  color: #1e293b;
+  border: 1px solid #1e293b;
+}
+
+.modal-button.confirm {
+  background-color: #14b8a6;
+  color: #fff;
+}
+
+.modal-button.confirm:hover {
+  background-color: #0d9488;
+}
+
+.modal-button.cancel:hover {
+  background-color: #e2e8f0;
+}

--- a/packages/frontend/src/Modal.tsx
+++ b/packages/frontend/src/Modal.tsx
@@ -30,11 +30,17 @@ const Modal: React.FC<ModalProps> = ({
 }) => {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCancel?.();
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel?.();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        onConfirm?.();
+      }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [onCancel]);
+  }, [onCancel, onConfirm]);
 
   const content = (
     <div className="modal-backdrop" onClick={onCancel}>
@@ -42,8 +48,16 @@ const Modal: React.FC<ModalProps> = ({
         <h3>{title}</h3>
         <div>{children}</div>
         <div className="modal-actions">
-          {onCancel && <button onClick={onCancel}>{cancelLabel}</button>}
-          {onConfirm && <button onClick={onConfirm}>{confirmLabel}</button>}
+          {onCancel && (
+            <button className="modal-button cancel" onClick={onCancel}>
+              {cancelLabel}
+            </button>
+          )}
+          {onConfirm && (
+            <button className="modal-button confirm" onClick={onConfirm}>
+              {confirmLabel}
+            </button>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- refresh modal styling to match the rest of the app
- add keyboard handling for <Enter> and <Esc> to confirm or cancel dialogs

## Testing
- `npm test --workspaces`

------
https://chatgpt.com/codex/tasks/task_e_68489ede86c8832bbd82067a85eebadd