### PR TITLE
Improve note color picker UX

### DIFF
--- a/packages/frontend/src/ColorPalette.tsx
+++ b/packages/frontend/src/ColorPalette.tsx
@@ -23,41 +23,37 @@ export const PALETTE_COLORS = [
 ];
 
 export const ColorPalette: React.FC<ColorPaletteProps> = ({ value, onChange }) => {
-  // Controls whether the palette is expanded or just shows the palette button
+  // Controls whether the palette popover is visible
   const [open, setOpen] = useState(false);
 
-  if (!open) {
-    return (
-      <div className="palette-toggle">
-        {/* Compact button shown when the palette is closed */}
-        <button
-          className="note-control palette-button"
-          onPointerDown={e => e.stopPropagation()}
-          onClick={() => setOpen(true)}
-          title="Change color"
-        >
-          <i className="fa-solid fa-palette" />
-        </button>
-      </div>
-    );
-  }
-
   return (
-    // Expanded palette of color choices
-    <div className="color-palette" onPointerDown={e => e.stopPropagation()}>
-      {PALETTE_COLORS.map((color) => (
-        <button
-          key={color}
-          className={`color-swatch${color === value ? ' selected' : ''}`}
-          style={{ backgroundColor: color }}
-          title="Change color"
-          onClick={() => {
-            // Update the parent with the new color and close the palette
-            onChange(color);
-            setOpen(false);
-          }}
-        />
-      ))}
+    <div className="palette-container" onPointerDown={e => e.stopPropagation()}>
+      {/* Toggle button to open/close the palette */}
+      <button
+        className="note-control palette-button"
+        onPointerDown={e => e.stopPropagation()}
+        onClick={() => setOpen(o => !o)}
+        title="Change color"
+      >
+        <i className="fa-solid fa-palette" />
+      </button>
+      {open && (
+        <div className="color-palette">
+          {PALETTE_COLORS.map((color) => (
+            <button
+              key={color}
+              className={`color-swatch${color === value ? ' selected' : ''}`}
+              style={{ backgroundColor: color }}
+              title="Change color"
+              onClick={() => {
+                // Update the parent with the new color and close the palette
+                onChange(color);
+                setOpen(false);
+              }}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/frontend/src/NoteControls.css
+++ b/packages/frontend/src/NoteControls.css
@@ -81,7 +81,9 @@
 }
 
 .color-palette {
-  position: relative;
+  position: absolute;
+  bottom: calc(100% + 4px / var(--zoom));
+  right: calc(-4px / var(--zoom));
   display: flex;
   gap: calc(4px / var(--zoom));
   background: rgba(255, 255, 255, 0.9);
@@ -92,7 +94,7 @@
   z-index: 10;
 }
 
-.palette-toggle {
+.palette-container {
   position: relative;
   width: calc(32px / var(--zoom));
   height: calc(32px / var(--zoom));


### PR DESCRIPTION
## Summary
- keep color button visible and toggle picker
- display palette above the button, offset slightly to the top right

## Testing
- `npm run build --workspace packages/frontend`
- `npm test --workspace packages/frontend`
- `npm run build --workspace packages/backend`
- `npm test --workspace packages/backend`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848a4139b40832b8a39f237bfb2111b