### PR TITLE
Move pin control into overflow menu

### DIFF
--- a/packages/frontend/src/NoteControls.css
+++ b/packages/frontend/src/NoteControls.css
@@ -134,6 +134,10 @@
   z-index: 10;
 }
 
+.note-menu .note-control {
+  position: static;
+}
+
 .color-swatch {
   width: calc(20px / var(--zoom));
   height: calc(20px / var(--zoom));

--- a/packages/frontend/src/NoteControls.tsx
+++ b/packages/frontend/src/NoteControls.tsx
@@ -40,14 +40,6 @@ export const NoteControls: React.FC<NoteControlsProps> = ({
       style={{ left: note.x, top: note.y, width: note.width, height: note.height }}
     >
       <div className="note-toolbar">
-        <button
-          className={`pin-back note-control${note.pinned ? ' active' : ''}`}
-          onPointerDown={e => e.stopPropagation()}
-          onClick={() => onSetPinned(note.id, !note.pinned)}
-          title={note.pinned ? 'Unpin from Back' : 'Pin to Back'}
-        >
-          <i className="fa-solid fa-thumbtack" />
-        </button>
         <ColorPalette
           value={note.color}
           onChange={(color) => onUpdate(note.id, { color })}
@@ -63,6 +55,13 @@ export const NoteControls: React.FC<NoteControlsProps> = ({
           </button>
           {menuOpen && (
             <div className="note-menu">
+              <button
+                className={`pin-back note-control${note.pinned ? ' active' : ''}`}
+                onClick={() => { onSetPinned(note.id, !note.pinned); setMenuOpen(false); }}
+                title={note.pinned ? 'Unpin from Back' : 'Pin to Back'}
+              >
+                <i className="fa-solid fa-thumbtack" />
+              </button>
               <button
                 className="note-control"
                 onClick={() => { onArchive(note.id, !note.archived); setMenuOpen(false); }}


### PR DESCRIPTION
## Summary
- move "pin to back" control from note toolbar into overflow menu
- ensure buttons inside the overflow menu are positioned correctly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848aacd5330832bb563915c037e7a8c