### PR TITLE
Add modal heading and paragraph spacing

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -235,6 +235,14 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
+.modal-content h3 {
+  margin: 0 0 1rem;
+}
+
+.modal-content p {
+  margin: 0 0 1rem;
+}
+
 .modal-actions {
   margin-top: 1rem;
   text-align: right;


### PR DESCRIPTION
## Summary
- tweak modal styling to add margins for headings and paragraphs

## Testing
- `npm test --workspace packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_6848aaeb6a40832ba60f5d404f826e09