### PR TITLE
Add note locking feature

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -79,6 +79,10 @@
   opacity: 0.6;
 }
 
+.note.locked {
+  border-style: dashed;
+}
+
 
 .note-text {
   width: 100%;

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -35,6 +35,10 @@ const App: React.FC = () => {
     appService.setNotePinned(id, pinned);
   };
 
+  const setNoteLocked = (id: number, locked: boolean) => {
+    appService.setNoteLocked(id, locked);
+  };
+
   const deleteNote = (id: number) => {
     appService.deleteNote(id);
   };
@@ -119,6 +123,7 @@ const App: React.FC = () => {
           onUpdate={updateNote}
           onArchive={(id, archived) => appService.archiveNote(id, archived)}
           onSetPinned={setNotePinned}
+          onSetLocked={setNoteLocked}
           onDelete={deleteNote}
           selectedId={selectedId}
           onSelect={handleSelect}

--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { StickyNote } from './StickyNote';
 import './App.css';
-import { Note } from './App';
+import { Note } from './services/AppService';
 import { clampZoom, zoomAroundCenter, zoomAroundPoint, MIN_ZOOM, MAX_ZOOM } from './zoomUtils';
 
 // Canvas that renders all sticky notes for the active workspace. Handles panning
@@ -16,6 +16,8 @@ export interface NoteCanvasProps {
   onArchive: (id: number, archived: boolean) => void;
   /** Pin or unpin a note behind all others */
   onSetPinned: (id: number, pinned: boolean) => void;
+  /** Lock or unlock a note */
+  onSetLocked: (id: number, locked: boolean) => void;
   /** Delete a note */
   onDelete: (id: number) => void;
   /** Id of the currently selected note */
@@ -37,6 +39,7 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
   onUpdate,
   onArchive,
   onSetPinned,
+  onSetLocked,
   onDelete,
   selectedId,
   onSelect,
@@ -112,8 +115,10 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
   const zoomRef = useRef(zoom);
 
   const pointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    // Start panning the board
-    onSelect(null);
+    // Start panning the board. If the pointer originated on a locked note,
+    // keep the selection so its controls remain accessible.
+    const locked = (e.target as HTMLElement).closest('.note.locked');
+    if (!locked) onSelect(null);
     panRef.current = {
       startX: e.clientX,
       startY: e.clientY,
@@ -310,6 +315,7 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
             onUpdate={onUpdate}
             onArchive={onArchive}
             onSetPinned={onSetPinned}
+            onSetLocked={onSetLocked}
             onDelete={onDelete}
             selected={selectedId === note.id}
             onSelect={onSelect}

--- a/packages/frontend/src/NoteControls.tsx
+++ b/packages/frontend/src/NoteControls.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Note } from './App';
+import { Note } from './services/AppService';
 import { ColorPalette } from './ColorPalette';
 import { useDialog } from './DialogService';
 import ConfirmDialog from './ConfirmDialog';
@@ -11,6 +11,7 @@ export interface NoteControlsProps {
   onUpdate: (id: number, data: Partial<Note>) => void;
   onArchive: (id: number, archived: boolean) => void;
   onSetPinned: (id: number, pinned: boolean) => void;
+  onSetLocked: (id: number, locked: boolean) => void;
   onDelete: (id: number) => void;
   overlayContainer: HTMLElement | null;
   onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
@@ -24,6 +25,7 @@ export const NoteControls: React.FC<NoteControlsProps> = ({
   onUpdate,
   onArchive,
   onSetPinned,
+  onSetLocked,
   onDelete,
   overlayContainer,
   onPointerDown,
@@ -63,6 +65,13 @@ export const NoteControls: React.FC<NoteControlsProps> = ({
                 <i className="fa-solid fa-thumbtack" />
               </button>
               <button
+                className={`note-control${note.locked ? ' active' : ''}`}
+                onClick={() => { onSetLocked(note.id, !note.locked); setMenuOpen(false); }}
+                title={note.locked ? 'Unlock' : 'Lock'}
+              >
+                <i className={`fa-solid ${note.locked ? 'fa-lock' : 'fa-lock-open'}`} />
+              </button>
+              <button
                 className="note-control"
                 onClick={() => { onArchive(note.id, !note.archived); setMenuOpen(false); }}
                 title={note.archived ? 'Unarchive' : 'Archive'}
@@ -94,15 +103,17 @@ export const NoteControls: React.FC<NoteControlsProps> = ({
           )}
         </div>
       </div>
-      <div
-        className="resize-handle note-control"
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
-        onPointerCancel={onPointerCancel}
-      >
-        <i className="fa-solid fa-up-right-and-down-left-from-center" />
-      </div>
+      {!note.locked && (
+        <div
+          className="resize-handle note-control"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerCancel}
+        >
+          <i className="fa-solid fa-up-right-and-down-left-from-center" />
+        </div>
+      )}
     </div>,
     overlayContainer
   );

--- a/packages/frontend/src/services/AppService.ts
+++ b/packages/frontend/src/services/AppService.ts
@@ -18,6 +18,7 @@ export interface Note {
   color: string;
   zIndex: number;
   pinned?: boolean;
+  locked?: boolean;
 }
 
 /** Canvas state for a workspace */
@@ -159,6 +160,7 @@ export class AppService extends EventEmitter {
       color: '#fef08a',
       zIndex: newZ,
       pinned: false,
+      locked: false,
     };
     ws.canvas.zCounter = newZ;
     ws.notes.push(note);
@@ -212,6 +214,15 @@ export class AppService extends EventEmitter {
     } else {
       this.bringNoteToFront(id);
     }
+  }
+
+  /** Lock or unlock a note */
+  setNoteLocked(id: number, locked: boolean): void {
+    const ws = this.currentWorkspace;
+    const note = ws.notes.find(n => n.id === id);
+    if (!note) return;
+    note.locked = locked;
+    this.emitChange();
   }
 
   /** Archive or unarchive a note */

--- a/packages/frontend/src/services/KeyWatcher.ts
+++ b/packages/frontend/src/services/KeyWatcher.ts
@@ -74,6 +74,7 @@ export class KeyWatcher {
       y: original.y + 20,
       archived: original.archived,
       pinned: original.pinned,
+      locked: original.locked,
     });
     this.opts.selectNote(newId);
   }


### PR DESCRIPTION
## Summary
- allow notes to be locked
- hide resize handle when locked and show lock toggle in menu
- prevent drag/resize for locked notes and pan canvas instead
- keep selection when panning over locked notes
- copy locked state when duplicating notes

## Testing
- `npm test --workspaces`
- `npm run build --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_6848ae815d08832bac8f86b4aec07f5e