### PR TITLE
Show lock indicator on locked notes

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -83,6 +83,15 @@
   border-style: dashed;
 }
 
+.note-lock-indicator {
+  position: absolute;
+  bottom: 2px;
+  left: 4px;
+  font-size: 0.75rem;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
 
 .note-text {
   width: 100%;

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -183,6 +183,11 @@ export const StickyNote: React.FC<StickyNoteProps> = ({ note, onUpdate, onArchiv
         // Static display of note content
         <div className={`note-content${note.content ? '' : ' placeholder'}`}>{note.content || 'Empty Note'}</div>
       )}
+      {note.locked && (
+        <div className="note-lock-indicator">
+          <i className="fa-solid fa-lock" />
+        </div>
+      )}
     </div>
     {overlayContainer && selected && !editing && (
       <NoteControls


### PR DESCRIPTION
## Summary
- show a lock icon on sticky notes that are locked
- style the indicator so it sits in the bottom left of a note

## Testing
- `npm run dev:frontend`

------
https://chatgpt.com/codex/tasks/task_e_6848b2c01a74832b83c8503f0d29b3c2