### PR TITLE
Integrate Cognito auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,22 @@ distribution.
   `cognito_hosted_ui_domain` values used when configuring the frontend
   authentication flow.
 
+### Authentication configuration
+
+The frontend requires a few environment variables so it can talk to your
+Cognito user pool. Create a `.env` file in `packages/frontend` with the
+following values:
+
+```bash
+VITE_COGNITO_USER_POOL_ID=<your-user-pool-id>
+VITE_COGNITO_CLIENT_ID=<your-app-client-id>
+VITE_COGNITO_DOMAIN=<your-hosted-ui-domain>
+VITE_COGNITO_REDIRECT_URI=<http://localhost:5173>
+```
+
+`VITE_COGNITO_REDIRECT_URI` should match one of the callback URLs specified in
+your Cognito app client settings.
+
 ### Deploying the frontend
 
 Once the infrastructure is created you can build and upload the frontend using

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,6 +8,7 @@
     "test": "echo 'no tests yet'"
   },
   "dependencies": {
+    "aws-amplify": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/frontend/src/AccountControls.tsx
+++ b/packages/frontend/src/AccountControls.tsx
@@ -80,6 +80,9 @@ export const AccountControls: React.FC<AccountControlsProps> = ({
         {user ? (
           <>
             <span className="welcome">Hello, {user.name}</span>
+            {user.email && (
+              <span className="email">({user.email})</span>
+            )}
             <button onClick={logout}>Logout</button>
           </>
         ) : (

--- a/packages/frontend/src/Login.tsx
+++ b/packages/frontend/src/Login.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { Auth } from 'aws-amplify';
+import { appService } from './services/AppService';
+
+/**
+ * Component used to initiate the Cognito hosted UI sign in flow and
+ * process the redirect back to the app.
+ */
+const Login: React.FC = () => {
+  useEffect(() => {
+    const handleAuth = async () => {
+      try {
+        // If the user already returned from Cognito this will resolve
+        // with their session and attributes. Otherwise it throws.
+        const cognitoUser = await Auth.currentAuthenticatedUser();
+        const attrs = (cognitoUser as any).attributes || {};
+        appService.setUser({
+          id: attrs.sub,
+          name: attrs.name || attrs.email || 'User',
+        });
+      } catch {
+        // No session yet so redirect to the hosted UI
+        await Auth.federatedSignIn();
+      }
+    };
+    void handleAuth();
+  }, []);
+
+  return <p>Redirecting to sign in…</p>;
+};
+
+export default Login;

--- a/packages/frontend/src/services/AppService.ts
+++ b/packages/frontend/src/services/AppService.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 export interface User {
   id: string;
   name: string;
+  email?: string;
 }
 
 /** Sticky note data model */


### PR DESCRIPTION
## Summary
- add AWS Amplify dependency for authentication
- capture Cognito user details in AppService and UserContext
- implement hosted UI flow in new `Login` component
- show account email and logout in account controls
- document Cognito environment variables

## Testing
- `npm test -w packages/frontend`
- `npm test -w packages/backend`
- `npm run build -w packages/frontend`
- `npm run build -w packages/backend`


------
https://chatgpt.com/codex/tasks/task_e_684902c0b978832b9c15f141658c9762