### PR TITLE
Add Vite config for frontend

### DIFF
--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -1,0 +1,24 @@
+# Frontend
+
+This package contains the React frontend powered by Vite.
+
+## Vite Configuration
+
+The `vite.config.ts` file defines an alias so libraries referencing the Node.js
+`global` object work in the browser:
+
+```ts
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  define: {
+    global: 'globalThis',
+  },
+});
+```
+
+Run the build with:
+
+```bash
+npm run build --workspace packages/frontend
+```

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  define: {
+    global: 'globalThis',
+  },
+});


### PR DESCRIPTION
## Summary
- add `vite.config.ts` so packages expecting Node.js global run in browser
- document how the alias works in a new frontend README

## Testing
- `npm run build --workspace packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_68490ae57970832b80b248f8e31371e8