### PR TITLE
Fix global not defined error in browser

### DIFF
--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -4,6 +4,13 @@ import App from './App';
 import { DialogProvider } from './DialogService';
 import './index.css';
 
+// Some third-party libraries such as `buffer` expect a Node-style `global`
+// object to exist. Vite's static `define` alias handles most cases during the
+// build step, but runtime code may still reference `global`. Explicitly
+// assigning `window` ensures those libraries work in the browser.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).global = window;
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <DialogProvider>


### PR DESCRIPTION
## Summary
- set `window.global` in `main.tsx` to support libraries expecting Node global

## Testing
- `npm run build --workspace packages/frontend`
- `npm test --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_68490c1bb254832b9325ed208701cc29