### PR TITLE
Fix missing redirect when signing out of Cognito

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,12 @@ VITE_COGNITO_USER_POOL_ID=<your-user-pool-id>
 VITE_COGNITO_CLIENT_ID=<your-app-client-id>
 VITE_COGNITO_DOMAIN=<your-hosted-ui-domain>
 VITE_COGNITO_REDIRECT_URI=<http://localhost:5173>
+VITE_COGNITO_LOGOUT_URI=<http://localhost:5173>
 ```
 
 `VITE_COGNITO_REDIRECT_URI` should match one of the callback URLs specified in
-your Cognito app client settings.
+your Cognito app client settings while `VITE_COGNITO_LOGOUT_URI` must be an
+allowed logout URL.
 
 ### Deploying the frontend
 

--- a/packages/frontend/src/UserContext.tsx
+++ b/packages/frontend/src/UserContext.tsx
@@ -43,6 +43,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     const clientId = import.meta.env.VITE_COGNITO_CLIENT_ID;
     const domain = import.meta.env.VITE_COGNITO_DOMAIN;
     const redirect = import.meta.env.VITE_COGNITO_REDIRECT_URI;
+    const logoutUri = import.meta.env.VITE_COGNITO_LOGOUT_URI || redirect;
 
     if (!userPoolId || !clientId || !domain || !redirect) return;
 
@@ -57,7 +58,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
           domain,
           scope: ['openid', 'email', 'profile'],
           redirectSignIn: redirect,
-          redirectSignOut: redirect,
+          redirectSignOut: logoutUri,
           responseType: 'code',
         },
       },


### PR DESCRIPTION
## Summary
- allow specifying `VITE_COGNITO_LOGOUT_URI`
- use new env var when configuring Amplify

## Testing
- `npm run build --workspaces`

------
https://chatgpt.com/codex/tasks/task_e_6849fd499e94832ba61283857bc42e8f