### PR TITLE
Extract User model to shared package

### DIFF
--- a/packages/frontend/src/UserContext.tsx
+++ b/packages/frontend/src/UserContext.tsx
@@ -5,17 +5,13 @@ import React, { createContext, useEffect, useState, ReactNode } from 'react';
 import { Amplify } from '@aws-amplify/core';
 import { Auth } from '@aws-amplify/auth';
 import { appService } from './services/AppService';
+import type { User } from '@sticky-notes/shared';
 
 // Simple context used by the demo application to represent an authenticated
 // user. In a real application this would be wired up to AWS Cognito or another
 // auth provider. Here we just expose `login` and `logout` helpers and keep the
 // user object in local React state.
 
-export interface User {
-  id: string;
-  name: string;
-  email?: string;
-}
 
 /**
  * Shape of the context value returned by {@link UserContext}.

--- a/packages/frontend/src/services/AppService.ts
+++ b/packages/frontend/src/services/AppService.ts
@@ -1,11 +1,6 @@
 import { EventEmitter } from 'events';
+import type { User } from '@sticky-notes/shared';
 
-/** User account model */
-export interface User {
-  id: string;
-  name: string;
-  email?: string;
-}
 
 /** Sticky note data model */
 export interface Note {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,5 @@
 // Example function exported from the shared package. In a real project this
 // would contain utilities used by both the frontend and backend packages.
 export const hello = () => 'Hello from shared library';
+
+export * from './models/User';

--- a/packages/shared/src/models/User.ts
+++ b/packages/shared/src/models/User.ts
@@ -1,0 +1,6 @@
+/** User account model */
+export interface User {
+  id: string;
+  name: string;
+  email?: string;
+}


### PR DESCRIPTION
## Summary
- add User model under packages/shared
- re-export User model in shared index
- use shared User interface in frontend code

## Testing
- `npm run build --workspaces`

------
https://chatgpt.com/codex/tasks/task_e_684a0747f4e4832bb26fbad4c3aa67b9