### PR TITLE
Fix Google federation scope error

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -137,7 +137,7 @@ resource "aws_cognito_user_pool_client" "web" {
   supported_identity_providers      = ["COGNITO", "Google"]
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_flows               = ["code"]
-  allowed_oauth_scopes              = ["email", "openid", "profile"]
+  allowed_oauth_scopes              = ["email", "openid", "profile", "aws.cognito.signin.user.admin"]
 }
 
 # Google identity provider

--- a/packages/frontend/src/UserContext.tsx
+++ b/packages/frontend/src/UserContext.tsx
@@ -68,7 +68,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         userPoolWebClientId: clientId,
         oauth: {
           domain,
-          scope: ['openid', 'email', 'profile'],
+          scope: ['openid', 'email', 'profile', 'aws.cognito.signin.user.admin'],
           redirectSignIn: redirect,
           redirectSignOut: logoutUri,
           responseType: 'code',


### PR DESCRIPTION
## Summary
- add `aws.cognito.signin.user.admin` scope in Amplify Auth setup
- expose same scope in Terraform config for the user pool client

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a4fcc7e60832ba4b984603a476376