### PR TITLE
Improve error logging in UserContext

### DIFF
--- a/packages/frontend/src/UserContext.tsx
+++ b/packages/frontend/src/UserContext.tsx
@@ -96,7 +96,8 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         setUser(u);
         appService.setUser(u);
       } catch (err) {
-        console.debug('currentAuthenticatedUser failed', err);
+        const message = (err as Error).message;
+        console.debug('currentAuthenticatedUser failed', message, err);
         // not signed in
         setUser(null);
         appService.setUser(null);


### PR DESCRIPTION
## Summary
- capture the message when the user load fails

## Testing
- `npm test --workspace packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_684a5ed8ce08832ba8ad74537e184e70