### PR TITLE
Move archive toggle into user dropdown

### DIFF
--- a/packages/frontend/src/AccountControls.tsx
+++ b/packages/frontend/src/AccountControls.tsx
@@ -99,7 +99,6 @@ export const AccountControls: React.FC<AccountControlsProps> = ({
       <div className="account-actions">
         {/* Primary actions for the current workspace */}
         <button className="add-note" onClick={onAddNote}><i className="fa-solid fa-plus" /> Add Note</button>
-        <button onClick={onToggleShowArchived}>{showArchived ? 'Hide Archived' : 'Show Archived'}</button>
         {user ? (
           <div ref={menuRef} className="user-menu">
             <button
@@ -111,6 +110,10 @@ export const AccountControls: React.FC<AccountControlsProps> = ({
             </button>
             {menuOpen && (
               <div className="user-dropdown">
+                <button onClick={onToggleShowArchived}>
+                  {showArchived ? 'Hide Archived' : 'Show Archived'}
+                </button>
+                <hr className="menu-divider" />
                 <button
                   onClick={() => {
                     logout();

--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -220,6 +220,12 @@
   min-width: 120px;
 }
 
+.user-dropdown .menu-divider {
+  border: none;
+  border-top: 1px solid #cbd5e1;
+  margin: 4px 0;
+}
+
 .user-dropdown button {
   background: none;
   border: none;


### PR DESCRIPTION
## Summary
- move 'Show/Hide Archived' toggle into the profile menu
- remove the toggle from the header
- add horizontal divider inside profile dropdown instead of spacing

## Testing
- `npm test --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_684b6c3027a4832b903d29b0c1ed6360