### PR TITLE
Support pasting note at context menu position

### DIFF
--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -245,7 +245,11 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
   };
 
   const handlePaste = () => {
-    const newId = pasteNote(appService);
+    if (!contextMenu) return;
+    // Convert the menu position from screen space to board coordinates
+    const boardX = (contextMenu.x - offset.x) / zoom;
+    const boardY = (contextMenu.y - offset.y) / zoom;
+    const newId = pasteNote(appService, boardX, boardY);
     if (newId != null) {
       onSelect(newId);
     }

--- a/packages/frontend/src/services/Clipboard.ts
+++ b/packages/frontend/src/services/Clipboard.ts
@@ -9,7 +9,11 @@ export function copyNote(service: AppService, id: number): void {
   clipboard = note ? { ...note } : null;
 }
 
-export function pasteNote(service: AppService): number | null {
+export function pasteNote(
+  service: AppService,
+  x?: number,
+  y?: number,
+): number | null {
   if (!clipboard) return null;
   const original = clipboard;
   const newId = service.addNote();
@@ -18,8 +22,8 @@ export function pasteNote(service: AppService): number | null {
     width: original.width,
     height: original.height,
     color: original.color,
-    x: original.x + 20,
-    y: original.y + 20,
+    x: x ?? original.x + 20,
+    y: y ?? original.y + 20,
     archived: original.archived,
     pinned: original.pinned,
     locked: original.locked,


### PR DESCRIPTION
## Summary
- allow specifying coordinates when pasting from clipboard
- paste note at the context menu position

## Testing
- `npm run test --workspace packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_684b7b572d58832bb7fc6bfbcac9846d