### PR TITLE
Add snap line guides when notes snap

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -48,6 +48,24 @@
   z-index: 100;
 }
 
+.snap-line {
+  position: absolute;
+  pointer-events: none;
+  border-color: rgba(59, 130, 246, 0.7);
+}
+
+.snap-line.vertical {
+  top: 0;
+  bottom: 0;
+  border-left: 1px dashed rgba(59, 130, 246, 0.7);
+}
+
+.snap-line.horizontal {
+  left: 0;
+  right: 0;
+  border-top: 1px dashed rgba(59, 130, 246, 0.7);
+}
+
 .note {
   background-color: #fff;
   border: 1px solid #e5e7eb;

--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -80,6 +80,7 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
   const offsetRef = useRef(offset);
   // Container used to render note controls above all notes
   const overlayRef = useRef<HTMLDivElement>(null);
+  const [snapLines, setSnapLines] = useState<{ x: number | null; y: number | null }>({ x: null, y: null });
   const menuRef = useRef<HTMLDivElement | null>(null);
   const [contextMenu, setContextMenu] = useState<
     { x: number; y: number; noteId: number | null }
@@ -414,6 +415,7 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
             allNotes={notes}
             snapToEdges={snapToEdges}
             overlayContainer={overlayRef.current}
+            onSnapLinesChange={setSnapLines}
           />
         ))}
       </div>
@@ -424,7 +426,20 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
           transform: `translate(${offset.x}px, ${offset.y}px) scale(${zoom})`,
           '--zoom': zoom,
         } as React.CSSProperties}
-      />
+      >
+        {snapLines.x != null && (
+          <div
+            className="snap-line vertical"
+            style={{ left: snapLines.x }}
+          />
+        )}
+        {snapLines.y != null && (
+          <div
+            className="snap-line horizontal"
+            style={{ top: snapLines.y }}
+          />
+        )}
+      </div>
       {contextMenu && (
         <div
           ref={menuRef}


### PR DESCRIPTION
## Summary
- store snapped x/y positions in `NoteCanvas`
- show vertical or horizontal snap guides in overlay
- report snapping from `StickyNote` when dragging/resizing
- add styles for `.snap-line`

## Testing
- `npm run build --workspace packages/frontend`
- `npm test --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_684b8ae55cdc832bb34c2edbc6ee2463