### PR TITLE
Add shape interaction options updater

### DIFF
--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -123,8 +123,22 @@ export const StickyNote: React.FC<StickyNoteProps> = ({
 
   const interactionsRef = useRef<ShapeInteractions<Note> | null>(null);
 
+  // Create a new ShapeInteractions instance whenever the note id changes
   useEffect(() => {
     interactionsRef.current = new ShapeInteractions<Note>({
+      shape: note,
+      allShapes: allNotes,
+      zoom,
+      offset,
+      snapToEdges,
+      onUpdate,
+      onSnapLinesChange,
+    });
+  }, [note.id]);
+
+  // Update interaction options when relevant props change
+  useEffect(() => {
+    interactionsRef.current?.updateOptions({
       shape: note,
       allShapes: allNotes,
       zoom,

--- a/packages/frontend/src/shapes/useShapeInteractions.ts
+++ b/packages/frontend/src/shapes/useShapeInteractions.ts
@@ -32,6 +32,11 @@ export class ShapeInteractions<T extends Shape> {
 
   constructor(private opts: ShapeInteractionOptions<T>) {}
 
+  /** Update the option values without resetting interaction state */
+  updateOptions(opts: ShapeInteractionOptions<T>) {
+    this.opts = { ...this.opts, ...opts };
+  }
+
   private toBoard(clientX: number, clientY: number) {
     const { zoom, offset } = this.opts;
     return { x: (clientX - offset.x) / zoom, y: (clientY - offset.y) / zoom };

--- a/packages/frontend/test/useShapeInteractions.test.js
+++ b/packages/frontend/test/useShapeInteractions.test.js
@@ -35,4 +35,22 @@ function create(shape, all = [], snap = false) {
   assert.strictEqual(shape.x, 100);
 })();
 
+// Updating options mid-drag should not reset the drag offset
+(function(){
+  const shape = { id: 1, x: 0, y: 0, width: 100, height: 100, zIndex: 1, color: '#fff', archived: false };
+  const { si } = create(shape);
+  si.pointerDown({ clientX: 0, clientY: 0, target: { closest: () => null }, pointerId: 1 });
+  si.updateOptions({
+    shape,
+    allShapes: [shape],
+    zoom: 1,
+    offset: { x: 0, y: 0 },
+    snapToEdges: false,
+    onUpdate: (_, d) => Object.assign(shape, d),
+    onSnapLinesChange: () => {}
+  });
+  si.pointerMove({ clientX: 20, clientY: 0 });
+  assert.strictEqual(shape.x, 20);
+})();
+
 console.log('useShapeInteractions tests passed');


### PR DESCRIPTION
## Summary
- update ShapeInteractions with `updateOptions` to keep internal state
- recreate interactions only when note ID changes and update options via effect
- test updating options mid-drag

## Testing
- `npm test --workspace packages/frontend`
- `npm run build --workspace packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_684b921d5410832bbcf430b2a77ee993