### PR TITLE
Refactor shape snapping to use bounds helper

### DIFF
--- a/packages/frontend/src/shapes/useShapeInteractions.ts
+++ b/packages/frontend/src/shapes/useShapeInteractions.ts
@@ -1,4 +1,5 @@
 import type { Shape } from '@sticky-notes/shared';
+import { getShapeBounds } from '@sticky-notes/shared';
 
 export type SnapLines = { x: number | null; y: number | null };
 
@@ -78,9 +79,11 @@ export class ShapeInteractions<T extends Shape> {
     let lineY: number | null = null;
     if (snapToEdges) {
       const threshold = SNAP_THRESHOLD / zoom;
-      const others = allShapes.filter(n => n.id !== shape.id);
-      const xEdges = others.flatMap(n => [n.x, n.x + n.width]);
-      const yEdges = others.flatMap(n => [n.y, n.y + n.height]);
+      const others = allShapes
+        .filter(n => n.id !== shape.id)
+        .map(getShapeBounds);
+      const xEdges = others.flatMap(b => [b.left, b.right]);
+      const yEdges = others.flatMap(b => [b.top, b.bottom]);
       const snappedLeft = snap(newX, xEdges, threshold);
       const snappedRight = snap(newX + shape.width, xEdges, threshold);
       if (Math.abs(snappedRight - (newX + shape.width)) < Math.abs(snappedLeft - newX)) {
@@ -116,9 +119,11 @@ export class ShapeInteractions<T extends Shape> {
     let lineY: number | null = null;
     if (snapToEdges) {
       const threshold = SNAP_THRESHOLD / zoom;
-      const others = allShapes.filter(n => n.id !== shape.id);
-      const xEdges = others.flatMap(n => [n.x, n.x + n.width]);
-      const yEdges = others.flatMap(n => [n.y, n.y + n.height]);
+      const others = allShapes
+        .filter(n => n.id !== shape.id)
+        .map(getShapeBounds);
+      const xEdges = others.flatMap(b => [b.left, b.right]);
+      const yEdges = others.flatMap(b => [b.top, b.bottom]);
       const snappedLeft = snap(newX, xEdges, threshold);
       const snappedRight = snap(newX + newWidth, xEdges, threshold);
       if (snappedLeft !== newX) {

--- a/packages/frontend/test/useShapeInteractions.test.js
+++ b/packages/frontend/test/useShapeInteractions.test.js
@@ -26,6 +26,7 @@ function create(shape, all = [], snap = false) {
 })();
 
 // Snapping when near other shape
+// Horizontal snapping when near other shape
 (function(){
   const shape = { id: 1, x: 0, y: 0, width: 50, height: 50, zIndex: 1, color: '#fff', archived: false };
   const other = { id: 2, x: 100, y: 0, width: 50, height: 50, zIndex: 1, color: '#fff', archived: false };
@@ -33,6 +34,16 @@ function create(shape, all = [], snap = false) {
   si.pointerDown({ clientX: 0, clientY: 0, target: { closest: () => null }, pointerId: 1 });
   si.pointerMove({ clientX: 93, clientY: 0 });
   assert.strictEqual(shape.x, 100);
+})();
+
+// Vertical snapping when near other shape
+(function(){
+  const shape = { id: 1, x: 0, y: 0, width: 50, height: 50, zIndex: 1, color: '#fff', archived: false };
+  const other = { id: 2, x: 0, y: 100, width: 50, height: 50, zIndex: 1, color: '#fff', archived: false };
+  const { si } = create(shape, [shape, other], true);
+  si.pointerDown({ clientX: 0, clientY: 0, target: { closest: () => null }, pointerId: 1 });
+  si.pointerMove({ clientX: 0, clientY: 93 });
+  assert.strictEqual(shape.y, 100);
 })();
 
 // Updating options mid-drag should not reset the drag offset

--- a/packages/shared/src/models/Shape.ts
+++ b/packages/shared/src/models/Shape.ts
@@ -10,3 +10,19 @@ export interface Shape {
   color: string;
   archived: boolean;
 }
+
+export type ShapeBounds = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+};
+
+export function getShapeBounds(shape: Pick<Shape, 'x' | 'y' | 'width' | 'height'>): ShapeBounds {
+  return {
+    left: shape.x,
+    top: shape.y,
+    right: shape.x + shape.width,
+    bottom: shape.y + shape.height,
+  };
+}


### PR DESCRIPTION
## Summary
- expose `getShapeBounds` util in shared package
- compute snap candidates from shape bounds in `ShapeInteractions`
- add vertical snapping case to the shape interaction tests

## Testing
- `npm run build --workspace packages/shared`
- `npm test --workspace packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_684b94430a38832b8dd5579806c00eaf