### PR TITLE
Fix ES module exports

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -13,6 +14,7 @@ export default defineConfig({
     resolve: {
         alias: {
             './runtimeConfig': './runtimeConfig.browser',
+            '@sticky-notes/shared': resolve(__dirname, '../shared/src'),
         },
     },
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,6 +2,6 @@
 // would contain utilities used by both the frontend and backend packages.
 export const hello = () => 'Hello from shared library';
 
-export * from './models/User';
-export * from './models/Shape';
-export * from './models/Note';
+export * from './models/User.js';
+export * from './models/Shape.js';
+export * from './models/Note.js';


### PR DESCRIPTION
## Summary
- add alias for shared src in Vite config
- include `.js` extensions in shared package exports

## Testing
- `npm test --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_684b9c0b2838832bae089111e658b8de