### PR TITLE
Adjust frontend deploy script for env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .env
+.env.deploy
 dist
 coverage
 package-lock.json

--- a/scripts/deploy_frontend.js
+++ b/scripts/deploy_frontend.js
@@ -13,6 +13,8 @@ if (!bucket || !distId) {
   process.exit(1);
 }
 
+run('cp packages/frontend/.env.deploy packages/frontend/.env');
+
 run('npm run build --workspace packages/frontend');
 run(`aws s3 sync packages/frontend/dist s3://${bucket} --delete --no-verify-ssl`);
 run(`aws cloudfront create-invalidation --distribution-id ${distId} --paths "/*"`);


### PR DESCRIPTION
## Summary
- copy `.env.deploy` to `.env` during frontend deployment
- ignore `.env.deploy` in Git

## Testing
- `npm test --workspaces`

------
https://chatgpt.com/codex/tasks/task_e_684baedb9230832bb0639ab4f1372444