### PR TITLE
Fix cp command for windows

### DIFF
--- a/scripts/deploy_frontend.js
+++ b/scripts/deploy_frontend.js
@@ -1,4 +1,5 @@
 const { execSync } = require('child_process');
+const fs = require('fs');
 
 function run(cmd, opts = {}) {
   console.log(cmd);
@@ -13,7 +14,9 @@ if (!bucket || !distId) {
   process.exit(1);
 }
 
-run('cp packages/frontend/.env.deploy packages/frontend/.env');
+// Copy .env.deploy to .env in a cross-platform way
+fs.copyFileSync('packages/frontend/.env.deploy', 'packages/frontend/.env');
+console.log('Copied packages/frontend/.env.deploy to packages/frontend/.env');
 
 run('npm run build --workspace packages/frontend');
 run(`aws s3 sync packages/frontend/dist s3://${bucket} --delete --no-verify-ssl`);


### PR DESCRIPTION
## Summary
- copy .env.deploy to .env using Node APIs instead of `cp`

## Testing
- `npm test --workspaces` *(fails: Cannot find package '/workspace/todo/node_modules/@sticky-notes/shared/dist/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_684bb0aee7dc832b95ea60310009d7ac