### PR TITLE
Add rotation field to shapes

### DIFF
--- a/packages/frontend/src/services/AppService.ts
+++ b/packages/frontend/src/services/AppService.ts
@@ -152,6 +152,7 @@ export class AppService extends EventEmitter {
       y: (-ws.canvas.offset.y + 40) / ws.canvas.zoom,
       width: 150,
       height: 120,
+      rotation: 0,
       archived: false,
       color: '#fef08a',
       zIndex: newZ,

--- a/packages/frontend/src/services/Clipboard.ts
+++ b/packages/frontend/src/services/Clipboard.ts
@@ -33,6 +33,7 @@ export function pasteNote(
     color: original.color,
     x: x ?? original.x + 20,
     y: y ?? original.y + 20,
+    rotation: original.rotation,
     archived: original.archived,
     pinned: original.pinned,
     locked: original.locked,

--- a/packages/shared/src/models/Shape.ts
+++ b/packages/shared/src/models/Shape.ts
@@ -5,6 +5,7 @@ export interface Shape {
   width: number;
   height: number;
   zIndex: number;
+  rotation: number;
   pinned?: boolean;
   locked?: boolean;
   color: string;


### PR DESCRIPTION
## Summary
- extend shape model with `rotation`
- default rotation to 0 when notes are created
- preserve rotation on paste

## Testing
- `npm run build`
- `npm test --workspace packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_684bb38d02e0832ba8fe3ef007d7a473