### PR TITLE
Add rotation tests

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
-    "test": "TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register test/useShapeInteractions.test.js"
+    "test": "TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register test/run-tests.js"
   },
   "dependencies": {
     "@aws-amplify/auth": "^5.6.15",

--- a/packages/frontend/test/appServiceRotation.test.js
+++ b/packages/frontend/test/appServiceRotation.test.js
@@ -1,0 +1,25 @@
+require('ts-node/register');
+const assert = require('assert');
+const { AppService } = require('../src/services/AppService');
+const { copyNote, pasteNote } = require('../src/services/Clipboard');
+
+(function testAddNoteRotation(){
+  const service = new AppService();
+  const id = service.addNote();
+  const ws = service.getState().workspaces[0];
+  const note = ws.notes.find(n => n.id === id);
+  assert.strictEqual(note.rotation, 0);
+})();
+
+(function testCopyPasteRotation(){
+  const service = new AppService();
+  const id = service.addNote();
+  service.updateNote(id, { rotation: 45 });
+  copyNote(service, id);
+  const newId = pasteNote(service);
+  const ws = service.getState().workspaces[0];
+  const pasted = ws.notes.find(n => n.id === newId);
+  assert.strictEqual(pasted.rotation, 45);
+})();
+
+console.log('appServiceRotation tests passed');

--- a/packages/frontend/test/run-tests.js
+++ b/packages/frontend/test/run-tests.js
@@ -1,0 +1,2 @@
+require('./useShapeInteractions.test.js');
+require('./appServiceRotation.test.js');


### PR DESCRIPTION
## Summary
- add tests for note rotation default and copy/paste
- run all frontend tests via a new `run-tests.js` helper

## Testing
- `npm run build`
- `npm test --workspace packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_684bb46fc140832baf3e34a22654be24