### PR TITLE
Add rotation interactions for shapes

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -77,6 +77,7 @@
   word-break: break-word;
   touch-action: none;
   transition: box-shadow 0.2s ease;
+  transform: rotate(var(--rotation, 0deg));
 }
 
 .note.selected {
@@ -89,7 +90,7 @@
 
 .note:hover {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
-  transform: scale(1.02);
+  transform: rotate(var(--rotation, 0deg)) scale(1.02);
   transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 

--- a/packages/frontend/src/NoteControls.css
+++ b/packages/frontend/src/NoteControls.css
@@ -172,6 +172,18 @@
   opacity: 1;
 }
 
+.rotate-handle {
+  top: calc(4px / var(--zoom));
+  left: calc(4px / var(--zoom));
+  cursor: grab;
+  opacity: 0.5;
+  transition: opacity 0.2s ease;
+}
+
+.rotate-handle:hover {
+  opacity: 1;
+}
+
 /* Stack menu items vertically on very small screens */
 @media (max-width: 480px) {
   .note-menu {

--- a/packages/frontend/src/NoteControls.tsx
+++ b/packages/frontend/src/NoteControls.tsx
@@ -139,6 +139,17 @@ export const NoteControls: React.FC<NoteControlsProps> = ({
           <i className="fa-solid fa-up-right-and-down-left-from-center" />
         </div>
       )}
+      {!note.locked && (
+        <div
+          className="rotate-handle note-control"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerCancel}
+        >
+          <i className="fa-solid fa-rotate" />
+        </div>
+      )}
     </div>,
     overlayContainer
   );

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -71,7 +71,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({
   onSnapLinesChange,
 }) => {
   // Track the current interaction mode (pinching only; drag/resize handled by ShapeInteractions)
-  const modeRef = useRef<'drag' | 'resize' | 'pinch' | null>(null);
+  const modeRef = useRef<'drag' | 'resize' | 'rotate' | 'pinch' | null>(null);
   // Track active touch points for pinch gestures
   const touchesRef = useRef(new Map<number, Point>());
   // Information about an active pinch gesture
@@ -189,6 +189,8 @@ export const StickyNote: React.FC<StickyNoteProps> = ({
 
     if (target.closest('.resize-handle')) {
       modeRef.current = 'resize';
+    } else if (target.closest('.rotate-handle')) {
+      modeRef.current = 'rotate';
     } else {
       modeRef.current = 'drag';
     }
@@ -272,6 +274,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({
         backgroundColor: note.color,
         borderColor: adjustColor(note.color, -30),
         zIndex: note.zIndex,
+        '--rotation': `${note.rotation}deg`,
       }}
       onPointerDown={pointerDown}
       onPointerMove={pointerMove}

--- a/packages/frontend/test/useShapeInteractions.test.js
+++ b/packages/frontend/test/useShapeInteractions.test.js
@@ -64,4 +64,13 @@ function create(shape, all = [], snap = false) {
   assert.strictEqual(shape.x, 20);
 })();
 
+// Rotation when using rotate handle
+(function(){
+  const shape = { id: 1, x: 0, y: 0, width: 100, height: 100, rotation: 0, zIndex: 1, color: '#fff', archived: false };
+  const { si } = create(shape);
+  si.pointerDown({ clientX: 100, clientY: 0, target: { closest: sel => sel === '.rotate-handle' ? {} : null }, pointerId: 1 });
+  si.pointerMove({ clientX: 0, clientY: 100 });
+  assert(Math.abs(shape.rotation - 180) < 1e-6);
+})();
+
 console.log('useShapeInteractions tests passed');


### PR DESCRIPTION
## Summary
- support rotation mode in `useShapeInteractions`
- expose rotate handle in note controls
- style rotation handle and allow notes to rotate
- adjust note hover scale to include rotation
- test rotation behaviour

## Testing
- `npm run build`
- `npm test --workspace packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_684bb565bde0832bac40b4bdf7437c4a