### PR TITLE
Add rotate handle to NoteControls

### DIFF
--- a/packages/frontend/src/NoteControls.css
+++ b/packages/frontend/src/NoteControls.css
@@ -173,8 +173,9 @@
 }
 
 .rotate-handle {
-  top: calc(4px / var(--zoom));
-  left: calc(4px / var(--zoom));
+  top: calc(-36px / var(--zoom));
+  left: 50%;
+  transform: translateX(-50%);
   cursor: grab;
   opacity: 0.5;
   transition: opacity 0.2s ease;

--- a/packages/frontend/src/NoteControls.tsx
+++ b/packages/frontend/src/NoteControls.tsx
@@ -64,7 +64,13 @@ export const NoteControls: React.FC<NoteControlsProps> = ({
   return createPortal(
     <div
       className="note-controls"
-      style={{ left: note.x, top: note.y, width: note.width, height: note.height }}
+      style={{
+        left: note.x,
+        top: note.y,
+        width: note.width,
+        height: note.height,
+        transform: `rotate(${note.rotation}deg)`,
+      }}
     >
       <div className="note-toolbar">
         <ColorPalette
@@ -140,7 +146,8 @@ export const NoteControls: React.FC<NoteControlsProps> = ({
         </div>
       )}
       {!note.locked && (
-        <div
+        <button
+          type="button"
           className="rotate-handle note-control"
           onPointerDown={onPointerDown}
           onPointerMove={onPointerMove}
@@ -148,7 +155,7 @@ export const NoteControls: React.FC<NoteControlsProps> = ({
           onPointerCancel={onPointerCancel}
         >
           <i className="fa-solid fa-rotate" />
-        </div>
+        </button>
       )}
     </div>,
     overlayContainer

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -274,6 +274,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({
         backgroundColor: note.color,
         borderColor: adjustColor(note.color, -30),
         zIndex: note.zIndex,
+        transform: `rotate(${note.rotation}deg)`,
         '--rotation': `${note.rotation}deg`,
       }}
       onPointerDown={pointerDown}


### PR DESCRIPTION
## Summary
- show rotate handle button in NoteControls
- position rotate handle above the note
- rotate notes and overlay with note rotation

## Testing
- `npm run build --workspace packages/shared`
- `npm test --workspace packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_684bb70a5574832b94140754eda03cf4