### PR TITLE
Fix rotation controls desync

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -94,6 +94,12 @@
   transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
+.note.interacting,
+.note.interacting:hover {
+  transform: rotate(var(--rotation, 0deg));
+  transition: none;
+}
+
 .note.archived {
   opacity: 0.6;
 }

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -88,6 +88,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({
   } | null>(null);
   // Whether the note text is currently being edited
   const [editing, setEditing] = useState(false);
+  const [interacting, setInteracting] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
   const MAX_FONT_SIZE = 1;
@@ -199,6 +200,9 @@ export const StickyNote: React.FC<StickyNoteProps> = ({
     } else {
       modeRef.current = 'drag';
     }
+    if (modeRef.current === 'drag' || modeRef.current === 'resize' || modeRef.current === 'rotate') {
+      setInteracting(true);
+    }
   };
 
   const pointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -247,6 +251,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({
 
   const pointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
     modeRef.current = null;
+    setInteracting(false);
     (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
     if (e.pointerType === 'touch') {
       touchesRef.current.delete(e.pointerId);
@@ -260,6 +265,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({
   const pointerCancel = (e: React.PointerEvent<HTMLDivElement>) => {
     if (note.locked) return;
     modeRef.current = null;
+    setInteracting(false);
     (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
     if (e.pointerType === 'touch') {
       touchesRef.current.delete(e.pointerId);
@@ -281,7 +287,7 @@ export const StickyNote: React.FC<StickyNoteProps> = ({
     <>
     <div
       data-note-id={note.id}
-      className={`note${note.archived ? ' archived' : ''}${selected ? ' selected' : ''}${editing ? ' editing' : ''}${note.locked ? ' locked' : ''}`}
+      className={`note${note.archived ? ' archived' : ''}${selected ? ' selected' : ''}${editing ? ' editing' : ''}${note.locked ? ' locked' : ''}${interacting ? ' interacting' : ''}`}
       style={{
         left: note.x,
         top: note.y,


### PR DESCRIPTION
## Summary
- track when a sticky note is actively being interacted with
- apply `.interacting` CSS class to disable transform/transition

## Testing
- `npm test --workspace packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_684c1d6243e8832ba14a1d5e1cc85582