### PR TITLE
Add responsive shape toolbar

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -200,6 +200,41 @@
   background-color: rgba(255, 255, 255, 0.2);
 }
 
+/* Toolbar shown below the header */
+.toolbar {
+  --zoom: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: #e2e8f0;
+  flex-wrap: wrap;
+}
+
+.toolbar button {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #1e293b;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+
+.toolbar button:hover {
+  background: #cbd5e1;
+}
+
+.toolbar-divider {
+  width: 1px;
+  height: 24px;
+  background: #94a3b8;
+}
+
 
 .welcome {
   margin-right: 0.5rem;
@@ -419,5 +454,13 @@
     margin: 0.25rem;
     padding: 0.5rem;
     font-size: 0.9rem;
+  }
+
+  .toolbar {
+    justify-content: center;
+  }
+
+  .toolbar button {
+    margin: 0.25rem;
   }
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import ConfirmDialog from './ConfirmDialog';
 import { UserProvider, UserContext } from './UserContext';
 import { AccountControls } from './AccountControls';
 import { NoteCanvas } from './NoteCanvas';
+import { ShapeToolbar } from './ShapeToolbar';
 import LoginOverlay from './LoginOverlay';
 import { KeyWatcher } from "./services/KeyWatcher";
 import { appService, AppState } from './services/AppService';
@@ -29,6 +30,7 @@ const AppContent: React.FC = () => {
   const currentWsIndex = workspaces.findIndex(w => w.id === currentWorkspaceId);
   const workspace = workspaces[currentWsIndex];
   const snapToEdges = workspace.canvas.snapToEdges;
+  const selectedNote = workspace.notes.find(n => n.id === selectedId) || null;
 
   const addNote = () => {
     appService.addNote();
@@ -160,6 +162,18 @@ const AppContent: React.FC = () => {
           onSwitchWorkspace={switchWorkspace}
           onRenameWorkspace={renameWorkspace}
           onDeleteWorkspace={deleteWorkspace}
+        />
+        <ShapeToolbar
+          selectedNote={selectedNote}
+          onUpdateNote={updateNote}
+          onSetPinned={setNotePinned}
+          onSetLocked={setNoteLocked}
+          onArchive={(id, a) => appService.archiveNote(id, a)}
+          onDelete={deleteNote}
+          showArchived={showArchived}
+          onToggleShowArchived={toggleShowArchived}
+          snapToEdges={snapToEdges}
+          onToggleSnap={toggleSnapToEdges}
         />
         <NoteCanvas
           notes={workspace.notes.filter(n => showArchived || !n.archived)}

--- a/packages/frontend/src/ShapeToolbar.tsx
+++ b/packages/frontend/src/ShapeToolbar.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import type { Note } from '@sticky-notes/shared';
+import { ColorPalette } from './ColorPalette';
+import './NoteControls.css';
+import './App.css';
+
+export interface ShapeToolbarProps {
+  selectedNote: Note | null;
+  onUpdateNote: (id: number, data: Partial<Note>) => void;
+  onSetPinned: (id: number, pinned: boolean) => void;
+  onSetLocked: (id: number, locked: boolean) => void;
+  onArchive: (id: number, archived: boolean) => void;
+  onDelete: (id: number) => void;
+  showArchived: boolean;
+  onToggleShowArchived: () => void;
+  snapToEdges: boolean;
+  onToggleSnap: () => void;
+}
+
+export const ShapeToolbar: React.FC<ShapeToolbarProps> = ({
+  selectedNote,
+  onUpdateNote,
+  onSetPinned,
+  onSetLocked,
+  onArchive,
+  onDelete,
+  showArchived,
+  onToggleShowArchived,
+  snapToEdges,
+  onToggleSnap,
+}) => {
+  return (
+    <div className="toolbar" style={{ '--zoom': 1 } as React.CSSProperties}>
+      {selectedNote && (
+        <>
+          <ColorPalette
+            value={selectedNote.color}
+            onChange={(color) => onUpdateNote(selectedNote.id, { color })}
+          />
+          <button
+            onClick={() => onSetPinned(selectedNote.id, !selectedNote.pinned)}
+            title={selectedNote.pinned ? 'Unpin from Back' : 'Pin to Back'}
+          >
+            <i className="fa-solid fa-thumbtack" />
+          </button>
+          <button
+            onClick={() => onSetLocked(selectedNote.id, !selectedNote.locked)}
+            title={selectedNote.locked ? 'Unlock' : 'Lock'}
+          >
+            <i className={`fa-solid ${selectedNote.locked ? 'fa-lock' : 'fa-lock-open'}`} />
+          </button>
+          <button
+            onClick={() => onArchive(selectedNote.id, !selectedNote.archived)}
+            title={selectedNote.archived ? 'Unarchive' : 'Archive'}
+          >
+            <i className={`fa-solid ${selectedNote.archived ? 'fa-box-open' : 'fa-box-archive'}`} />
+          </button>
+          <button onClick={() => onDelete(selectedNote.id)} title="Delete">
+            <i className="fa-solid fa-trash" />
+          </button>
+          <div className="toolbar-divider" />
+        </>
+      )}
+      <button onClick={onToggleShowArchived} title={showArchived ? 'Hide Archived' : 'Show Archived'}>
+        <i className={`fa-solid ${showArchived ? 'fa-eye-slash' : 'fa-eye'}`} />
+      </button>
+      <button onClick={onToggleSnap} title={snapToEdges ? 'Disable Snap' : 'Enable Snap'}>
+        <i className="fa-solid fa-magnet" />
+      </button>
+    </div>
+  );
+};

--- a/packages/frontend/src/StickyNote.tsx
+++ b/packages/frontend/src/StickyNote.tsx
@@ -332,11 +332,6 @@ export const StickyNote: React.FC<StickyNoteProps> = ({
     {overlayContainer && selected && !editing && (
       <NoteControls
         note={note}
-        onUpdate={onUpdate}
-        onArchive={onArchive}
-        onSetPinned={onSetPinned}
-        onSetLocked={onSetLocked}
-        onDelete={onDelete}
         overlayContainer={overlayContainer}
         onPointerDown={pointerDown}
         onPointerMove={pointerMove}


### PR DESCRIPTION
## Summary
- create `ShapeToolbar` with note and canvas actions
- style toolbar and make responsive
- remove note menu from `NoteControls`
- hook toolbar into `App` and adjust `StickyNote`

## Testing
- `npm run build`
- `npm run -ws test`

------
https://chatgpt.com/codex/tasks/task_e_684c1ebc7d4c832b95de3f468f6aeaac