### PR TITLE
Fix color palette dropdown

### DIFF
--- a/packages/frontend/src/NoteControls.css
+++ b/packages/frontend/src/NoteControls.css
@@ -82,7 +82,7 @@
 
 .color-palette {
   position: absolute;
-  bottom: calc(100% + 4px / var(--zoom));
+  top: calc(100% + 4px / var(--zoom));
   right: calc(-4px / var(--zoom));
   display: flex;
   gap: calc(4px / var(--zoom));


### PR DESCRIPTION
## Summary
- update CSS so color palette menu opens below the color button

## Testing
- `npm run build --silent`
- `npm --workspace packages/frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c2156807c832b883648fafa877516