### PR TITLE
Remove archive/snap toggles from profile menu

### DIFF
--- a/packages/frontend/src/AccountControls.tsx
+++ b/packages/frontend/src/AccountControls.tsx
@@ -16,14 +16,6 @@ export interface WorkspaceInfo {
 export interface AccountControlsProps {
   /** Callback fired when the "Add Note" button is pressed */
   onAddNote: () => void;
-  /** Whether archived notes are currently visible */
-  showArchived: boolean;
-  /** Toggle the archived filter */
-  onToggleShowArchived: () => void;
-  /** Whether snap to edges is enabled */
-  snapToEdges: boolean;
-  /** Toggle snapping behavior */
-  onToggleSnap: () => void;
   /** List of available workspaces for the workspace selector */
   workspaces: WorkspaceInfo[];
   /** Id of the workspace currently being displayed */
@@ -40,10 +32,6 @@ export interface AccountControlsProps {
 // Renders account actions and the workspace selector shown at the top of the UI.
 export const AccountControls: React.FC<AccountControlsProps> = ({
   onAddNote,
-  showArchived,
-  onToggleShowArchived,
-  snapToEdges,
-  onToggleSnap,
   workspaces,
   currentWorkspaceId,
   onCreateWorkspace,
@@ -122,12 +110,6 @@ export const AccountControls: React.FC<AccountControlsProps> = ({
             </button>
             {menuOpen && (
               <div className="user-dropdown">
-                <button onClick={onToggleShowArchived}>
-                  {showArchived ? 'Hide Archived' : 'Show Archived'}
-                </button>
-                <button onClick={onToggleSnap}>
-                  {snapToEdges ? 'Disable Snap' : 'Enable Snap'}
-                </button>
                 {currentWorkspaceId !== 1 && (
                   <button
                     onClick={async () => {

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -152,10 +152,6 @@ const AppContent: React.FC = () => {
     <div className="app">
         <AccountControls
           onAddNote={addNote}
-          showArchived={showArchived}
-          onToggleShowArchived={toggleShowArchived}
-          snapToEdges={snapToEdges}
-          onToggleSnap={toggleSnapToEdges}
           workspaces={workspaces.map(w => ({ id: w.id, name: w.name }))}
           currentWorkspaceId={currentWorkspaceId}
           onCreateWorkspace={createWorkspace}


### PR DESCRIPTION
## Summary
- update AccountControls component to drop archive/snap props
- remove archive and snap menu buttons
- adjust App to call AccountControls without those props

## Testing
- `npm run build --workspace packages/frontend`
- `npm test --workspace packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_684c2244f13c832bbe6ab03db85d4fbd