### PR TITLE
Move add note action to shape toolbar

### DIFF
--- a/packages/frontend/src/AccountControls.tsx
+++ b/packages/frontend/src/AccountControls.tsx
@@ -5,8 +5,7 @@ import ConfirmDialog from './ConfirmDialog';
 import './App.css';
 
 // Header area that displays workspace management controls and a simple
-// authentication menu. It also exposes buttons for toggling archived notes and
-// creating new sticky notes.
+// authentication menu.
 
 export interface WorkspaceInfo {
   id: number;
@@ -14,16 +13,6 @@ export interface WorkspaceInfo {
 }
 
 export interface AccountControlsProps {
-  /** Callback fired when the "Add Note" button is pressed */
-  onAddNote: () => void;
-  /** Whether archived notes are currently visible */
-  showArchived: boolean;
-  /** Toggle the archived filter */
-  onToggleShowArchived: () => void;
-  /** Whether snap to edges is enabled */
-  snapToEdges: boolean;
-  /** Toggle snapping behavior */
-  onToggleSnap: () => void;
   /** List of available workspaces for the workspace selector */
   workspaces: WorkspaceInfo[];
   /** Id of the workspace currently being displayed */
@@ -39,11 +28,6 @@ export interface AccountControlsProps {
 }
 // Renders account actions and the workspace selector shown at the top of the UI.
 export const AccountControls: React.FC<AccountControlsProps> = ({
-  onAddNote,
-  showArchived,
-  onToggleShowArchived,
-  snapToEdges,
-  onToggleSnap,
   workspaces,
   currentWorkspaceId,
   onCreateWorkspace,
@@ -109,8 +93,6 @@ export const AccountControls: React.FC<AccountControlsProps> = ({
         )}
       </div>
       <div className="account-actions">
-        {/* Primary actions for the current workspace */}
-        <button className="add-note" onClick={onAddNote}><i className="fa-solid fa-plus" /> Add Note</button>
         {user ? (
           <div ref={menuRef} className="user-menu">
             <button
@@ -122,12 +104,6 @@ export const AccountControls: React.FC<AccountControlsProps> = ({
             </button>
             {menuOpen && (
               <div className="user-dropdown">
-                <button onClick={onToggleShowArchived}>
-                  {showArchived ? 'Hide Archived' : 'Show Archived'}
-                </button>
-                <button onClick={onToggleSnap}>
-                  {snapToEdges ? 'Disable Snap' : 'Enable Snap'}
-                </button>
                 {currentWorkspaceId !== 1 && (
                   <button
                     onClick={async () => {

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -151,11 +151,6 @@ const AppContent: React.FC = () => {
   return (
     <div className="app">
         <AccountControls
-          onAddNote={addNote}
-          showArchived={showArchived}
-          onToggleShowArchived={toggleShowArchived}
-          snapToEdges={snapToEdges}
-          onToggleSnap={toggleSnapToEdges}
           workspaces={workspaces.map(w => ({ id: w.id, name: w.name }))}
           currentWorkspaceId={currentWorkspaceId}
           onCreateWorkspace={createWorkspace}
@@ -164,6 +159,7 @@ const AppContent: React.FC = () => {
           onDeleteWorkspace={deleteWorkspace}
         />
         <ShapeToolbar
+          onAddNote={addNote}
           selectedNote={selectedNote}
           onUpdateNote={updateNote}
           onSetPinned={setNotePinned}

--- a/packages/frontend/src/ShapeToolbar.tsx
+++ b/packages/frontend/src/ShapeToolbar.tsx
@@ -5,6 +5,7 @@ import './NoteControls.css';
 import './App.css';
 
 export interface ShapeToolbarProps {
+  onAddNote: () => void;
   selectedNote: Note | null;
   onUpdateNote: (id: number, data: Partial<Note>) => void;
   onSetPinned: (id: number, pinned: boolean) => void;
@@ -18,6 +19,7 @@ export interface ShapeToolbarProps {
 }
 
 export const ShapeToolbar: React.FC<ShapeToolbarProps> = ({
+  onAddNote,
   selectedNote,
   onUpdateNote,
   onSetPinned,
@@ -31,6 +33,10 @@ export const ShapeToolbar: React.FC<ShapeToolbarProps> = ({
 }) => {
   return (
     <div className="toolbar" style={{ '--zoom': 1 } as React.CSSProperties}>
+      <button onClick={onAddNote} title="Add Note">
+        <i className="fa-solid fa-plus" />
+      </button>
+      <div className="toolbar-divider" />
       {selectedNote && (
         <>
           <ColorPalette


### PR DESCRIPTION
## Summary
- move the Add Note action out of the header controls
- add Add Note button to the shape toolbar with a divider
- keep profile menu clean without archive and snap toggles

## Testing
- `npm test --workspace packages/frontend`
- `npm run build --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_684c227b69fc832ba9e127f04a273ea4