### PR TITLE
Move add note button to toolbar

### DIFF
--- a/packages/frontend/src/AccountControls.tsx
+++ b/packages/frontend/src/AccountControls.tsx
@@ -5,8 +5,7 @@ import ConfirmDialog from './ConfirmDialog';
 import './App.css';
 
 // Header area that displays workspace management controls and a simple
-// authentication menu. It also exposes buttons for toggling archived notes and
-// creating new sticky notes.
+// authentication menu.
 
 export interface WorkspaceInfo {
   id: number;
@@ -14,8 +13,6 @@ export interface WorkspaceInfo {
 }
 
 export interface AccountControlsProps {
-  /** Callback fired when the "Add Note" button is pressed */
-  onAddNote: () => void;
   /** List of available workspaces for the workspace selector */
   workspaces: WorkspaceInfo[];
   /** Id of the workspace currently being displayed */
@@ -31,7 +28,6 @@ export interface AccountControlsProps {
 }
 // Renders account actions and the workspace selector shown at the top of the UI.
 export const AccountControls: React.FC<AccountControlsProps> = ({
-  onAddNote,
   workspaces,
   currentWorkspaceId,
   onCreateWorkspace,
@@ -97,8 +93,6 @@ export const AccountControls: React.FC<AccountControlsProps> = ({
         )}
       </div>
       <div className="account-actions">
-        {/* Primary actions for the current workspace */}
-        <button className="add-note" onClick={onAddNote}><i className="fa-solid fa-plus" /> Add Note</button>
         {user ? (
           <div ref={menuRef} className="user-menu">
             <button

--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -179,10 +179,6 @@
   font-size: 1rem;
   cursor: pointer;
 }
-.account .add-note {
-  background-color: #3b82f6;
-  border-color: #3b82f6;
-}
 .workspace-controls select {
   margin-right: 0.5rem;
   padding: 0.5rem 0.75rem;

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -151,7 +151,6 @@ const AppContent: React.FC = () => {
   return (
     <div className="app">
         <AccountControls
-          onAddNote={addNote}
           workspaces={workspaces.map(w => ({ id: w.id, name: w.name }))}
           currentWorkspaceId={currentWorkspaceId}
           onCreateWorkspace={createWorkspace}
@@ -160,6 +159,7 @@ const AppContent: React.FC = () => {
           onDeleteWorkspace={deleteWorkspace}
         />
         <ShapeToolbar
+          onAddNote={addNote}
           selectedNote={selectedNote}
           onUpdateNote={updateNote}
           onSetPinned={setNotePinned}

--- a/packages/frontend/src/ShapeToolbar.tsx
+++ b/packages/frontend/src/ShapeToolbar.tsx
@@ -5,6 +5,7 @@ import './NoteControls.css';
 import './App.css';
 
 export interface ShapeToolbarProps {
+  onAddNote: () => void;
   selectedNote: Note | null;
   onUpdateNote: (id: number, data: Partial<Note>) => void;
   onSetPinned: (id: number, pinned: boolean) => void;
@@ -18,6 +19,7 @@ export interface ShapeToolbarProps {
 }
 
 export const ShapeToolbar: React.FC<ShapeToolbarProps> = ({
+  onAddNote,
   selectedNote,
   onUpdateNote,
   onSetPinned,
@@ -31,6 +33,10 @@ export const ShapeToolbar: React.FC<ShapeToolbarProps> = ({
 }) => {
   return (
     <div className="toolbar" style={{ '--zoom': 1 } as React.CSSProperties}>
+      <button onClick={onAddNote} title="Add Note">
+        <i className="fa-solid fa-plus" />
+      </button>
+      <div className="toolbar-divider" />
       {selectedNote && (
         <>
           <ColorPalette


### PR DESCRIPTION
## Summary
- shift `Add Note` control from header to the toolbar
- show `Add Note` as first toolbar button and separate it from edit tools
- remove unused header styling for the old button location

## Testing
- `npm run build --workspace packages/shared`
- `npm test --workspace packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_684c25e8ab28832bb0b9001326a9a778