### PR TITLE
Fix color palette spacing on small screens

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -465,4 +465,10 @@
   .toolbar button {
     margin: 0.25rem;
   }
+
+  /* Ensure custom toolbar controls like the color palette
+     get the same spacing as regular buttons */
+  .toolbar .palette-container {
+    margin: 0.25rem;
+  }
 }


### PR DESCRIPTION
## Summary
- ensure color picker has same margin as other toolbar controls on narrow screens

## Testing
- `npm run build`
- `npm test --workspace packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_684c27600eb0832b8f2a16aa1ebd2dce