### PR TITLE
Fix color palette orientation

### DIFF
--- a/packages/frontend/src/NoteControls.css
+++ b/packages/frontend/src/NoteControls.css
@@ -85,6 +85,7 @@
   top: calc(100% + 4px / var(--zoom));
   right: calc(-4px / var(--zoom));
   display: flex;
+  flex-direction: column;
   gap: calc(4px / var(--zoom));
   background: rgba(255, 255, 255, 0.9);
   padding: calc(4px / var(--zoom));


### PR DESCRIPTION
## Summary
- open the note color picker vertically

## Testing
- `npm run build --workspaces`
- `npm test --workspaces --if-present`


------
https://chatgpt.com/codex/tasks/task_e_684c288ecd30832b8e43c7b82dc555c1