### PR TITLE
Fix header layout on small screens

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -434,20 +434,21 @@
 /* Responsive tweaks for narrow screens */
 @media (max-width: 600px) {
   .account {
-    flex-direction: column;
-    align-items: stretch;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
   }
 
   .workspace-controls {
-    margin-bottom: 0.5rem;
+    margin-bottom: 0;
     display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
   }
 
   .account-actions {
-    flex-wrap: wrap;
-    justify-content: center;
+    flex-wrap: nowrap;
+    justify-content: flex-end;
   }
 
   .account button,


### PR DESCRIPTION
## Summary
- keep account controls laid out horizontally on narrow screens

## Testing
- `npm run build --workspaces`
- `npm test --workspace packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_684c28e22a94832b8206c069d6236f38