### PR TITLE
Fix color picker alignment

### DIFF
--- a/packages/frontend/src/NoteControls.css
+++ b/packages/frontend/src/NoteControls.css
@@ -99,11 +99,16 @@
   position: relative;
   width: calc(32px / var(--zoom));
   height: calc(32px / var(--zoom));
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .palette-button {
   border-radius: 50%;
   position: static;
+  width: 100%;
+  height: 100%;
 }
 
 .palette-button:hover {


### PR DESCRIPTION
## Summary
- center the color palette button within its container
- ensure the palette button fills its container

## Testing
- `npm run build --workspace packages/shared`
- `npm test --workspace packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_684c2b7a9240832b9e11338e13a89112