### PR TITLE
Add workspace CRUD handlers

### DIFF
--- a/packages/backend/src/workspaces.ts
+++ b/packages/backend/src/workspaces.ts
@@ -1,0 +1,89 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { Workspace } from '@sticky-notes/shared';
+
+/**
+ * Create a new workspace. Accepts a partial Workspace in the request body and
+ * returns the created Workspace object. This is a placeholder implementation
+ * that simply echoes the provided values with a generated id.
+ */
+export const createWorkspace: APIGatewayProxyHandler = async (event) => {
+  const input: Partial<Workspace> = event.body ? JSON.parse(event.body) : {};
+
+  const workspace: Workspace = {
+    id: Date.now(),
+    name: input.name ?? 'Untitled workspace',
+    ownerId: input.ownerId ?? null,
+    contributorIds: input.contributorIds ?? [],
+  };
+
+  return {
+    statusCode: 201,
+    body: JSON.stringify(workspace),
+  };
+};
+
+/**
+ * Retrieve a workspace by id. In this placeholder implementation the returned
+ * data is not persisted anywhere and simply returns an example Workspace.
+ */
+export const getWorkspace: APIGatewayProxyHandler = async (event) => {
+  const id = event.pathParameters?.id;
+
+  const workspace: Workspace = {
+    id: id ? Number(id) : 1,
+    name: 'Example Workspace',
+    ownerId: 'user-123',
+    contributorIds: [],
+  };
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(workspace),
+  };
+};
+
+/**
+ * Update an existing workspace. Accepts partial Workspace fields in the request
+ * body and returns the updated object. Data is not persisted yet.
+ */
+export const updateWorkspace: APIGatewayProxyHandler = async (event) => {
+  const id = event.pathParameters?.id;
+  const updates: Partial<Workspace> = event.body ? JSON.parse(event.body) : {};
+
+  const workspace: Workspace = {
+    id: id ? Number(id) : 1,
+    name: updates.name ?? 'Updated Workspace',
+    ownerId: updates.ownerId ?? 'user-123',
+    contributorIds: updates.contributorIds ?? [],
+  };
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(workspace),
+  };
+};
+
+/**
+ * Delete a workspace. Simply returns a 204 status code to indicate success.
+ */
+export const deleteWorkspace: APIGatewayProxyHandler = async () => {
+  return {
+    statusCode: 204,
+    body: '',
+  };
+};
+
+/**
+ * List workspaces accessible to the caller. Returns a few example items.
+ */
+export const listWorkspaces: APIGatewayProxyHandler = async () => {
+  const workspaces: Workspace[] = [
+    { id: 1, name: 'Example 1', ownerId: 'user-123', contributorIds: [] },
+    { id: 2, name: 'Example 2', ownerId: null, contributorIds: ['user-123'] },
+  ];
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(workspaces),
+  };
+};

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -5,7 +5,11 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "baseUrl": "./src",
+    "paths": {
+      "@sticky-notes/shared": ["../../shared/src"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add placeholder Lambda handlers for workspaces CRUD
- map shared package in backend tsconfig for type resolution

## Testing
- `npm run build --workspaces`

------
https://chatgpt.com/codex/tasks/task_e_684c36954794832b94ba9a7d74cea98f