### PR TITLE
Add backend README

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -1,0 +1,35 @@
+# Backend
+
+This package contains the serverless backend used by the Sticky Notes app. It currently exposes a small Lambda handler for local development but will later persist data in AWS services.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 16 or newer
+- AWS credentials available via environment variables or your AWS config/credentials file
+
+## Development
+
+Run the development handler with:
+
+```bash
+npm start
+```
+
+This executes `src/handler.ts` using `ts-node`.
+
+To create a production build run:
+
+```bash
+npm run build
+```
+
+The compiled JavaScript will be output to the `dist/` folder.
+
+## Environment variables
+
+Future persistence logic will rely on these variables:
+
+- `TABLE_NAME` – DynamoDB table where notes and workspaces are stored
+- `AWS_REGION` – AWS region used for service calls
+- `LOG_LEVEL` – optional verbosity setting for debugging
+


### PR DESCRIPTION
## Summary
- add usage instructions and environment variable outline for backend

## Testing
- `npm test --workspace packages/backend`

------
https://chatgpt.com/codex/tasks/task_e_684c3986137c832bbe5bdae8ddafc422