### PR TITLE
Add backend tests and scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "dev:frontend": "npm start --workspace packages/frontend",
     "dev:backend": "npm start --workspace packages/backend",
     "build": "npm run build --workspaces",
-    "deploy:frontend": "node ./scripts/deploy_frontend.js"
+    "deploy:frontend": "node ./scripts/deploy_frontend.js",
+    "test:backend": "npm test --workspace packages/backend",
+    "test": "npm run test:backend"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "ts-node src/handler.ts",
     "build": "tsc",
-    "test": "echo 'no tests yet'"
+    "test": "TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register test/run-tests.js"
   },
   "dependencies": {
     "aws-sdk": "^2.0.0"

--- a/packages/backend/test/run-tests.js
+++ b/packages/backend/test/run-tests.js
@@ -1,0 +1,1 @@
+require('./workspaces.test.js');

--- a/packages/backend/test/workspaces.test.js
+++ b/packages/backend/test/workspaces.test.js
@@ -1,0 +1,47 @@
+require('ts-node/register');
+const assert = require('assert');
+const { createWorkspace, getWorkspace, updateWorkspace, deleteWorkspace, listWorkspaces } = require('../src/workspaces');
+
+(async function testCreateWorkspace(){
+  const event = { body: JSON.stringify({ name: 'My WS', ownerId: 'user1', contributorIds: ['user2'] }) };
+  const res = await createWorkspace(event);
+  assert.strictEqual(res.statusCode, 201);
+  const ws = JSON.parse(res.body);
+  assert.strictEqual(ws.name, 'My WS');
+  assert.strictEqual(ws.ownerId, 'user1');
+  assert.deepStrictEqual(ws.contributorIds, ['user2']);
+})();
+
+(async function testGetWorkspace(){
+  const event = { pathParameters: { id: '5' } };
+  const res = await getWorkspace(event);
+  assert.strictEqual(res.statusCode, 200);
+  const ws = JSON.parse(res.body);
+  assert.strictEqual(ws.id, 5);
+})();
+
+(async function testUpdateWorkspace(){
+  const event = { pathParameters: { id: '1' }, body: JSON.stringify({ name: 'Updated', ownerId: 'user2', contributorIds: [] }) };
+  const res = await updateWorkspace(event);
+  assert.strictEqual(res.statusCode, 200);
+  const ws = JSON.parse(res.body);
+  assert.strictEqual(ws.id, 1);
+  assert.strictEqual(ws.name, 'Updated');
+  assert.strictEqual(ws.ownerId, 'user2');
+})();
+
+(async function testDeleteWorkspace(){
+  const res = await deleteWorkspace({});
+  assert.strictEqual(res.statusCode, 204);
+  assert.strictEqual(res.body, '');
+})();
+
+(async function testListWorkspaces(){
+  const res = await listWorkspaces({});
+  assert.strictEqual(res.statusCode, 200);
+  const arr = JSON.parse(res.body);
+  assert.ok(Array.isArray(arr));
+  assert.ok(arr.length >= 2);
+})();
+
+console.log('backend workspaces tests passed');


### PR DESCRIPTION
## Summary
- add workspace tests for backend
- execute backend tests with ts-node
- provide root command to run backend tests

## Testing
- `npm test --workspace packages/backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c3a656890832b98c56505c4d733a1