### PR TITLE
Add ESLint and Prettier setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "root": true,
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "ignorePatterns": ["dist/", "node_modules/"]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ production bundle for the frontend only, run:
 npm run build --workspace packages/frontend
 ```
 
+## Code Quality
+
+Run ESLint and Prettier from the repository root:
+
+```bash
+npm run lint    # check code style
+npm run format  # automatically format files
+```
+
 ## Deployment
 
 Infrastructure is managed with [Terraform](https://www.terraform.io/).  The

--- a/package.json
+++ b/package.json
@@ -2,13 +2,23 @@
   "name": "sticky-notes-monorepo",
   "private": true,
   "version": "0.1.0",
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "dev:frontend": "npm start --workspace packages/frontend",
     "dev:backend": "npm start --workspace packages/backend",
     "build": "npm run build --workspaces",
     "deploy:frontend": "node ./scripts/deploy_frontend.js",
     "test:backend": "npm test --workspace packages/backend",
-    "test": "npm run test:backend"
+    "test": "npm run test:backend",
+    "lint": "eslint \"**/*.{js,ts,tsx}\"",
+    "format": "prettier --write \"**/*.{js,ts,tsx,json,md}\""
+  },
+  "devDependencies": {
+    "eslint": "^8.56.0",
+    "@typescript-eslint/parser": "^6.18.1",
+    "@typescript-eslint/eslint-plugin": "^6.18.1",
+    "prettier": "^3.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint configuration extending recommended TypeScript rules
- add Prettier configuration
- install linting dependencies and expose `lint` and `format` scripts
- document how to run linting and formatting

## Testing
- `npm test`
- `npm run lint` *(fails: Require statement not part of import statement and other ESLint errors)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684c3b21fa68832bb6e3fa0cc1720137