### PR TITLE
Use structuredClone for AppService snapshots

### DIFF
--- a/packages/frontend/src/services/AppService.ts
+++ b/packages/frontend/src/services/AppService.ts
@@ -54,7 +54,7 @@ export class AppService extends EventEmitter {
 
   /** Get a readonly snapshot of the current state. */
   getState(): AppState {
-    return JSON.parse(JSON.stringify(this.state));
+    return structuredClone(this.state);
   }
 
   /** Subscribe to state changes. Returns an unsubscribe function. */

--- a/packages/frontend/test/appServiceImmutability.test.js
+++ b/packages/frontend/test/appServiceImmutability.test.js
@@ -1,0 +1,18 @@
+require('ts-node/register');
+const assert = require('assert');
+const { AppService } = require('../src/services/AppService');
+
+(function testStateSnapshotImmutability(){
+  const service = new AppService();
+  const id = service.addNote();
+  const snapshot = service.getState();
+  snapshot.user = { id: 123 };
+  snapshot.workspaces[0].notes[0].content = 'changed';
+
+  const fresh = service.getState();
+  assert.strictEqual(fresh.user, null);
+  const note = fresh.workspaces[0].notes.find(n => n.id === id);
+  assert.strictEqual(note.content, '');
+})();
+
+console.log('appServiceImmutability tests passed');

--- a/packages/frontend/test/run-tests.js
+++ b/packages/frontend/test/run-tests.js
@@ -1,2 +1,3 @@
 require('./useShapeInteractions.test.js');
 require('./appServiceRotation.test.js');
+require('./appServiceImmutability.test.js');


### PR DESCRIPTION
## Summary
- switch AppService.getState to `structuredClone`
- add test covering state snapshot immutability
- run frontend and backend tests

## Testing
- `npm test --workspace packages/frontend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c3ea7eb70832b820c256acb4a1211