### PR TITLE
Add typed event emitter interface and apply to AppService

### DIFF
--- a/packages/frontend/src/services/AppService.ts
+++ b/packages/frontend/src/services/AppService.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import type { User, Note, Workspace as SharedWorkspace } from '@sticky-notes/shared';
+import type { TypedEmitter, User, Note, Workspace as SharedWorkspace } from '@sticky-notes/shared';
 
 
 
@@ -24,6 +24,10 @@ export interface AppState {
   currentWorkspaceId: number;
 }
 
+interface AppServiceEvents {
+  change: [AppState];
+}
+
 /**
  * Centralized service responsible for storing application state. All
  * components should mutate state through this service so that future API
@@ -31,7 +35,7 @@ export interface AppState {
  *
  * The service emits a `"change"` event whenever state updates.
  */
-export class AppService extends EventEmitter {
+export class AppService extends EventEmitter implements TypedEmitter<AppServiceEvents> {
   private state: AppState;
 
   constructor() {

--- a/packages/shared/src/TypedEmitter.ts
+++ b/packages/shared/src/TypedEmitter.ts
@@ -1,0 +1,10 @@
+import { EventEmitter } from 'events';
+
+export interface TypedEmitter<E extends Record<PropertyKey, unknown[]>> extends EventEmitter {
+  addListener<EventKey extends keyof E>(event: EventKey, listener: (...args: E[EventKey]) => void): this;
+  on<EventKey extends keyof E>(event: EventKey, listener: (...args: E[EventKey]) => void): this;
+  once<EventKey extends keyof E>(event: EventKey, listener: (...args: E[EventKey]) => void): this;
+  removeListener<EventKey extends keyof E>(event: EventKey, listener: (...args: E[EventKey]) => void): this;
+  off<EventKey extends keyof E>(event: EventKey, listener: (...args: E[EventKey]) => void): this;
+  emit<EventKey extends keyof E>(event: EventKey, ...args: E[EventKey]): boolean;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,3 +6,4 @@ export * from './models/User.js';
 export * from './models/Shape.js';
 export * from './models/Note.js';
 export * from './models/Workspace.js';
+export * from './TypedEmitter.js';


### PR DESCRIPTION
## Summary
- add generic `TypedEmitter` interface to shared utils
- re-export `TypedEmitter` from shared index
- make `AppService` implement `TypedEmitter<{ change: [AppState] }>`

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c423fa788832b9b5d1454b7232d45