### PR TITLE
Add backend implementation plan

### DIFF
--- a/docs/backend-implementation-plan.md
+++ b/docs/backend-implementation-plan.md
@@ -1,0 +1,28 @@
+# Backend Implementation Plan
+
+This plan outlines the practical steps to build out the serverless backend.
+See [backend-design.md](./backend-design.md) for the overall architecture.
+
+1. **Set up DynamoDB table and environment configuration.**
+   - Create the single-table layout described in the design document.
+   - Configure table name and AWS region via environment variables for Lambda.
+
+2. **Implement CRUD Lambda functions for workspaces and notes.**
+   - Provide create, read, update and delete handlers.
+   - Use the shared models and persist data in DynamoDB.
+
+3. **Add membership checks for shared workspaces.**
+   - Ensure only owners and contributors can modify a workspace or its notes.
+   - Deny unauthorized actions with appropriate HTTP status codes.
+
+4. **Introduce WebSocket connection handling for broadcasting changes.**
+   - Use API Gateway or AppSync to manage connections.
+   - Publish workspace and note events to connected clients.
+
+5. **Update front-end service (`AppService`) to call the API and subscribe for updates.**
+   - Replace placeholder methods with real API calls.
+   - Subscribe to WebSocket events to keep the UI in sync.
+
+6. **Provide a testing strategy for new handlers.**
+   - Add unit tests for each Lambda function using the existing test framework.
+   - Include integration tests for WebSocket broadcasting.


### PR DESCRIPTION
## Summary
- add `docs/backend-implementation-plan.md` with tasks for building out the serverless backend

## Testing
- `npm test`
- `npm run lint` *(fails: 18 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c4ff3eca0832bb08d4554d8e40ff9