### PR TITLE
Add backend infrastructure

### DIFF
--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -50,3 +50,14 @@ variable "cognito_domain_prefix" {
   description = "Unique prefix for Cognito hosted UI domain"
   type        = string
 }
+
+variable "table_name" {
+  description = "DynamoDB table name for backend data"
+  type        = string
+}
+
+variable "api_stage" {
+  description = "Deployment stage name for API Gateway"
+  type        = string
+  default     = "prod"
+}


### PR DESCRIPTION
## Summary
- provision DynamoDB for user/workspace/note records
- add Lambda packaging and IAM execution role
- expose REST API Gateway with Cognito authentication
- allow deployment stage and table name to be customized

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c53f227a4832bb6f73b7190e92a4d