### PR TITLE
Implement DynamoDB workspace handlers

### DIFF
--- a/packages/backend/src/workspaces.ts
+++ b/packages/backend/src/workspaces.ts
@@ -1,5 +1,10 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
+import { DynamoDB } from 'aws-sdk';
 import { Workspace } from '@sticky-notes/shared';
+import { getUserId, hasWorkspaceAccess } from './auth';
+
+const TABLE_NAME = process.env.TABLE_NAME as string;
+const db = new DynamoDB.DocumentClient();
 
 /**
  * Create a new workspace. Accepts a partial Workspace in the request body and
@@ -7,14 +12,39 @@ import { Workspace } from '@sticky-notes/shared';
  * that simply echoes the provided values with a generated id.
  */
 export const createWorkspace: APIGatewayProxyHandler = async (event) => {
+  const userId = getUserId(event);
   const input: Partial<Workspace> = event.body ? JSON.parse(event.body) : {};
 
   const workspace: Workspace = {
     id: Date.now(),
     name: input.name ?? 'Untitled workspace',
-    ownerId: input.ownerId ?? null,
+    ownerId: userId,
     contributorIds: input.contributorIds ?? [],
   };
+
+  await db
+    .put({
+      TableName: TABLE_NAME,
+      Item: {
+        PK: `WORKSPACE#${workspace.id}`,
+        SK: 'META',
+        ...workspace,
+      },
+    })
+    .promise();
+
+  await db
+    .update({
+      TableName: TABLE_NAME,
+      Key: { PK: `USER#${userId}`, SK: 'META' },
+      UpdateExpression:
+        'SET ownedWorkspaceIds = list_append(if_not_exists(ownedWorkspaceIds, :empty), :w)',
+      ExpressionAttributeValues: {
+        ':w': [workspace.id],
+        ':empty': [],
+      },
+    })
+    .promise();
 
   return {
     statusCode: 201,
@@ -27,14 +57,24 @@ export const createWorkspace: APIGatewayProxyHandler = async (event) => {
  * data is not persisted anywhere and simply returns an example Workspace.
  */
 export const getWorkspace: APIGatewayProxyHandler = async (event) => {
+  const userId = getUserId(event);
   const id = event.pathParameters?.id;
+  if (!id) {
+    return { statusCode: 400, body: 'Missing id' };
+  }
 
-  const workspace: Workspace = {
-    id: id ? Number(id) : 1,
-    name: 'Example Workspace',
-    ownerId: 'user-123',
-    contributorIds: [],
-  };
+  const data = await db
+    .get({ TableName: TABLE_NAME, Key: { PK: `WORKSPACE#${id}`, SK: 'META' } })
+    .promise();
+  const workspace = data.Item as Workspace | undefined;
+
+  if (!workspace) {
+    return { statusCode: 404, body: 'Workspace not found' };
+  }
+
+  if (!hasWorkspaceAccess(workspace, userId)) {
+    return { statusCode: 403, body: 'Forbidden' };
+  }
 
   return {
     statusCode: 200,
@@ -47,26 +87,90 @@ export const getWorkspace: APIGatewayProxyHandler = async (event) => {
  * body and returns the updated object. Data is not persisted yet.
  */
 export const updateWorkspace: APIGatewayProxyHandler = async (event) => {
+  const userId = getUserId(event);
   const id = event.pathParameters?.id;
-  const updates: Partial<Workspace> = event.body ? JSON.parse(event.body) : {};
+  if (!id) {
+    return { statusCode: 400, body: 'Missing id' };
+  }
 
-  const workspace: Workspace = {
-    id: id ? Number(id) : 1,
-    name: updates.name ?? 'Updated Workspace',
-    ownerId: updates.ownerId ?? 'user-123',
-    contributorIds: updates.contributorIds ?? [],
-  };
+  const existing = await db
+    .get({ TableName: TABLE_NAME, Key: { PK: `WORKSPACE#${id}`, SK: 'META' } })
+    .promise();
+  const workspace = existing.Item as Workspace | undefined;
+
+  if (!workspace) {
+    return { statusCode: 404, body: 'Workspace not found' };
+  }
+
+  if (!hasWorkspaceAccess(workspace, userId)) {
+    return { statusCode: 403, body: 'Forbidden' };
+  }
+
+  const updates: Partial<Workspace> = event.body ? JSON.parse(event.body) : {};
+  const exprParts: string[] = [];
+  const names: Record<string, string> = {};
+  const values: Record<string, any> = {};
+
+  if (updates.name !== undefined) {
+    names['#n'] = 'name';
+    values[':n'] = updates.name;
+    exprParts.push('#n = :n');
+  }
+  if (updates.ownerId !== undefined) {
+    names['#o'] = 'ownerId';
+    values[':o'] = updates.ownerId;
+    exprParts.push('#o = :o');
+  }
+  if (updates.contributorIds !== undefined) {
+    names['#c'] = 'contributorIds';
+    values[':c'] = updates.contributorIds;
+    exprParts.push('#c = :c');
+  }
+
+  const updated = await db
+    .update({
+      TableName: TABLE_NAME,
+      Key: { PK: `WORKSPACE#${id}`, SK: 'META' },
+      UpdateExpression: 'SET ' + exprParts.join(', '),
+      ExpressionAttributeNames: names,
+      ExpressionAttributeValues: values,
+      ReturnValues: 'ALL_NEW',
+    })
+    .promise();
 
   return {
     statusCode: 200,
-    body: JSON.stringify(workspace),
+    body: JSON.stringify(updated.Attributes),
   };
 };
 
 /**
  * Delete a workspace. Simply returns a 204 status code to indicate success.
  */
-export const deleteWorkspace: APIGatewayProxyHandler = async () => {
+export const deleteWorkspace: APIGatewayProxyHandler = async (event) => {
+  const userId = getUserId(event);
+  const id = event.pathParameters?.id;
+  if (!id) {
+    return { statusCode: 400, body: 'Missing id' };
+  }
+
+  const res = await db
+    .get({ TableName: TABLE_NAME, Key: { PK: `WORKSPACE#${id}`, SK: 'META' } })
+    .promise();
+  const workspace = res.Item as Workspace | undefined;
+
+  if (!workspace) {
+    return { statusCode: 404, body: 'Workspace not found' };
+  }
+
+  if (!hasWorkspaceAccess(workspace, userId)) {
+    return { statusCode: 403, body: 'Forbidden' };
+  }
+
+  await db
+    .delete({ TableName: TABLE_NAME, Key: { PK: `WORKSPACE#${id}`, SK: 'META' } })
+    .promise();
+
   return {
     statusCode: 204,
     body: '',
@@ -76,11 +180,31 @@ export const deleteWorkspace: APIGatewayProxyHandler = async () => {
 /**
  * List workspaces accessible to the caller. Returns a few example items.
  */
-export const listWorkspaces: APIGatewayProxyHandler = async () => {
-  const workspaces: Workspace[] = [
-    { id: 1, name: 'Example 1', ownerId: 'user-123', contributorIds: [] },
-    { id: 2, name: 'Example 2', ownerId: null, contributorIds: ['user-123'] },
-  ];
+export const listWorkspaces: APIGatewayProxyHandler = async (event) => {
+  const userId = getUserId(event);
+
+  const user = await db
+    .get({ TableName: TABLE_NAME, Key: { PK: `USER#${userId}`, SK: 'META' } })
+    .promise();
+
+  const owned: number[] = user.Item?.ownedWorkspaceIds ?? [];
+  const contrib: number[] = user.Item?.contributedWorkspaceIds ?? [];
+  const ids = Array.from(new Set([...owned, ...contrib]));
+
+  if (ids.length === 0) {
+    return { statusCode: 200, body: '[]' };
+  }
+
+  const res = await db
+    .batchGet({
+      RequestItems: {
+        [TABLE_NAME]: {
+          Keys: ids.map((id) => ({ PK: `WORKSPACE#${id}`, SK: 'META' })),
+        },
+      },
+    })
+    .promise();
+  const workspaces = (res.Responses?.[TABLE_NAME] as Workspace[]) || [];
 
   return {
     statusCode: 200,


### PR DESCRIPTION
## Summary
- use DynamoDB in workspace handlers
- enforce owner or contributor permissions via auth helpers

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'authorizer'))*

------
https://chatgpt.com/codex/tasks/task_e_684c56e088c8832b9e35168e2fadee80