### PR TITLE
Add backend deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,3 +208,31 @@ For Windows cmd.exe:
 set S3_BUCKET="$(terraform -chdir=infra output -raw bucket_name)"
 set CLOUDFRONT_DISTRIBUTION_ID="$(terraform -chdir=infra output -raw cloudfront_distribution_id)"
 ```
+
+### Backend Deployment
+
+Update the Lambda function after making backend changes with:
+
+```bash
+npm run deploy:backend
+```
+
+The script compiles the backend, packages the Lambda code and uploads it using the AWS CLI. Set the `LAMBDA_FUNCTION_NAME` environment variable to the function name, which can be retrieved from Terraform outputs:
+
+For Bash or other Unix shells:
+
+```bash
+export LAMBDA_FUNCTION_NAME=$(terraform -chdir=infra output -raw lambda_function_name)
+```
+
+For PowerShell:
+
+```powershell
+$Env:LAMBDA_FUNCTION_NAME = terraform -chdir=infra output -raw lambda_function_name
+```
+
+For Windows cmd.exe:
+
+```cmd
+set LAMBDA_FUNCTION_NAME="$(terraform -chdir=infra output -raw lambda_function_name)"
+```

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -530,3 +530,7 @@ output "api_invoke_url" {
 output "ws_endpoint" {
   value = "${aws_apigatewayv2_api.ws.api_endpoint}/${var.api_stage}"
 }
+
+output "lambda_function_name" {
+  value = aws_lambda_function.backend.function_name
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev:backend": "npm start --workspace packages/backend",
     "build": "npm run build --workspaces",
     "deploy:frontend": "node ./scripts/deploy_frontend.js",
+    "deploy:backend": "node ./scripts/deploy_backend.js",
     "test:backend": "npm test --workspace packages/backend",
     "test": "npm run test:backend",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",

--- a/scripts/deploy_backend.js
+++ b/scripts/deploy_backend.js
@@ -1,0 +1,42 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function run(cmd, opts = {}) {
+  console.log(cmd);
+  execSync(cmd, { stdio: 'inherit', shell: true, ...opts });
+}
+
+// Determine Lambda function name from env
+const functionName = process.env.LAMBDA_FUNCTION_NAME;
+
+if (!functionName) {
+  console.error('LAMBDA_FUNCTION_NAME environment variable must be set');
+  process.exit(1);
+}
+
+// Build the backend package
+run('npm run build --workspace packages/backend');
+
+const distDir = path.join(__dirname, '../packages/backend/dist');
+const zipPath = path.join(__dirname, '../packages/backend/backend.zip');
+
+if (fs.existsSync(zipPath)) {
+  fs.unlinkSync(zipPath);
+}
+
+// Package the compiled Lambda code
+run(`cd ${distDir} && zip -r ${zipPath} .`);
+
+// Deploy the zip to AWS
+run(`aws lambda update-function-code --function-name ${functionName} --zip-file fileb://${zipPath}`);
+
+// Print API endpoint from Terraform outputs
+try {
+  const apiUrl = execSync('terraform -chdir=infra output -raw api_invoke_url').toString().trim();
+  console.log(`API URL: ${apiUrl}`);
+} catch (err) {
+  console.warn('Unable to read api_invoke_url from Terraform:', err.message);
+}
+
+console.log('Backend deployment complete');


### PR DESCRIPTION
## Summary
- add deploy_backend.js for packaging and deploying Lambda
- expose Lambda function name from Terraform outputs
- document backend deployment steps
- wire deploy:backend script in package.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c62690548832b912fbf876bdc8ae0