### PR TITLE
Fix base path mapping arg

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -123,7 +123,7 @@ resource "aws_api_gateway_domain_name" "api" {
 
 resource "aws_api_gateway_base_path_mapping" "api" {
   domain_name = aws_api_gateway_domain_name.api.domain_name
-  rest_api_id = aws_api_gateway_rest_api.main.id
+  api_id      = aws_api_gateway_rest_api.main.id
   stage_name  = var.api_stage
 }
 


### PR DESCRIPTION
## Summary
- fix base path mapping arguments for API Gateway

## Testing
- `terraform -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c70c0d2f8832b9d7f11b895e1b240