### PR TITLE
Fix API Gateway deployment warning

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -521,7 +521,12 @@ resource "aws_api_gateway_deployment" "main" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.main.id
-  stage_name  = var.api_stage
+}
+
+resource "aws_api_gateway_stage" "main" {
+  stage_name    = var.api_stage
+  rest_api_id   = aws_api_gateway_rest_api.main.id
+  deployment_id = aws_api_gateway_deployment.main.id
 }
 
 


### PR DESCRIPTION
## Summary
- manage REST API stage via `aws_api_gateway_stage`

## Testing
- `npm test`
- `npm run lint` *(fails: Require statement not part of import statement)*

------
https://chatgpt.com/codex/tasks/task_e_684c72b71518832b9a3acc789e171707