### PR TITLE
Fix websocket payload format and handler

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -511,7 +511,7 @@ resource "aws_apigatewayv2_integration" "ws_lambda" {
   api_id           = aws_apigatewayv2_api.ws.id
   integration_type = "AWS_PROXY"
   integration_uri  = aws_lambda_function.backend.invoke_arn
-  payload_format_version = "2.0"
+  payload_format_version = "1.0"
 }
 
 resource "aws_apigatewayv2_route" "ws_connect" {

--- a/packages/backend/src/websocket.ts
+++ b/packages/backend/src/websocket.ts
@@ -1,4 +1,4 @@
-import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { APIGatewayProxyHandler } from 'aws-lambda';
 import { DynamoDB, ApiGatewayManagementApi } from 'aws-sdk';
 
 const TABLE_NAME = process.env.TABLE_NAME as string;
@@ -7,7 +7,7 @@ const WS_ENDPOINT = process.env.WS_ENDPOINT as string;
 const db = new DynamoDB.DocumentClient();
 const api = WS_ENDPOINT ? new ApiGatewayManagementApi({ endpoint: WS_ENDPOINT }) : undefined;
 
-export const subscribe: APIGatewayProxyHandlerV2 = async (event) => {
+export const subscribe: APIGatewayProxyHandler = async (event) => {
   const connectionId = event.requestContext.connectionId as string;
   const body = event.body ? JSON.parse(event.body) : {};
   const workspaceId = body.workspaceId;
@@ -28,7 +28,7 @@ export const subscribe: APIGatewayProxyHandlerV2 = async (event) => {
   return { statusCode: 200, body: 'Subscribed' };
 };
 
-export const unsubscribe: APIGatewayProxyHandlerV2 = async (event) => {
+export const unsubscribe: APIGatewayProxyHandler = async (event) => {
   const connectionId = event.requestContext.connectionId as string;
   const body = event.body ? JSON.parse(event.body) : {};
   const workspaceId = body.workspaceId;
@@ -49,7 +49,7 @@ export const unsubscribe: APIGatewayProxyHandlerV2 = async (event) => {
   return { statusCode: 200, body: 'Unsubscribed' };
 };
 
-export const disconnect: APIGatewayProxyHandlerV2 = async (event) => {
+export const disconnect: APIGatewayProxyHandler = async (event) => {
   const connectionId = event.requestContext.connectionId as string;
 
   const scan = await db


### PR DESCRIPTION
## Summary
- use the correct payload_format_version for websocket integration
- switch websocket handlers to API Gateway proxy v1 events

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684c7cade608832b8fbc325eac7a958d