### PR TITLE
Use archiver in backend deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Update the Lambda function after making backend changes with:
 npm run deploy:backend
 ```
 
-The script compiles the backend, packages the Lambda code and uploads it using the AWS CLI. Set the `LAMBDA_FUNCTION_NAME` environment variable to the function name, which can be retrieved from Terraform outputs:
+The script compiles the backend, packages the Lambda code using the Node [archiver](https://www.npmjs.com/package/archiver) library (so no separate `zip` tool is required) and uploads it with the AWS CLI. Set the `LAMBDA_FUNCTION_NAME` environment variable to the function name, which can be retrieved from Terraform outputs:
 
 For Bash or other Unix shells:
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "format": "prettier --write \"**/*.{js,ts,tsx,json,md}\""
   },
   "devDependencies": {
-    "eslint": "^8.56.0",
-    "@typescript-eslint/parser": "^6.18.1",
     "@typescript-eslint/eslint-plugin": "^6.18.1",
+    "@typescript-eslint/parser": "^6.18.1",
+    "archiver": "^7.0.1",
+    "eslint": "^8.56.0",
     "prettier": "^3.1.1"
   }
 }

--- a/scripts/deploy_backend.js
+++ b/scripts/deploy_backend.js
@@ -1,6 +1,7 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const archiver = require('archiver');
 
 function run(cmd, opts = {}) {
   console.log(cmd);
@@ -25,18 +26,39 @@ if (fs.existsSync(zipPath)) {
   fs.unlinkSync(zipPath);
 }
 
-// Package the compiled Lambda code
-run(`cd ${distDir} && zip -r ${zipPath} .`);
+// Package the compiled Lambda code without relying on the zip CLI
+function createZip(sourceDir, outPath) {
+  return new Promise((resolve, reject) => {
+    const output = fs.createWriteStream(outPath);
+    const archive = archiver('zip', { zlib: { level: 9 } });
 
-// Deploy the zip to AWS
-run(`aws lambda update-function-code --function-name ${functionName} --zip-file fileb://${zipPath}`);
+    output.on('close', resolve);
+    archive.on('error', reject);
 
-// Print API endpoint from Terraform outputs
-try {
-  const apiUrl = execSync('terraform -chdir=infra output -raw api_invoke_url').toString().trim();
-  console.log(`API URL: ${apiUrl}`);
-} catch (err) {
-  console.warn('Unable to read api_invoke_url from Terraform:', err.message);
+    archive.directory(sourceDir, false);
+    archive.pipe(output);
+    archive.finalize();
+  });
 }
 
-console.log('Backend deployment complete');
+async function main() {
+  await createZip(distDir, zipPath);
+
+  // Deploy the zip to AWS
+  run(`aws lambda update-function-code --function-name ${functionName} --zip-file fileb://${zipPath}`);
+
+  // Print API endpoint from Terraform outputs
+  try {
+    const apiUrl = execSync('terraform -chdir=infra output -raw api_invoke_url').toString().trim();
+    console.log(`API URL: ${apiUrl}`);
+  } catch (err) {
+    console.warn('Unable to read api_invoke_url from Terraform:', err.message);
+  }
+
+  console.log('Backend deployment complete');
+}
+
+main().catch((err) => {
+  console.error('Deployment failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- use `archiver` in `deploy_backend.js` to create backend.zip
- add `archiver` as a dev dependency
- document how backend deployment uses `archiver`

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: unexpected any & unused-vars errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c83863a38832bafaacedea504e33a