### PR TITLE
Hydrate frontend state via API

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -33,7 +33,7 @@ const AppContent: React.FC = () => {
   const selectedNote = workspace.notes.find(n => n.id === selectedId) || null;
 
   const addNote = () => {
-    appService.addNote();
+    void appService.addNote();
   };
 
   const updateNote = (id: number, data: Partial<Note>) => {
@@ -107,7 +107,7 @@ const AppContent: React.FC = () => {
           onCancel={close.reject}
         />
       ));
-      appService.createWorkspace(name.trim());
+      await appService.createWorkspace(name.trim());
       setSelectedId(null);
     } catch {
       /* cancelled */
@@ -115,7 +115,7 @@ const AppContent: React.FC = () => {
   };
 
   const deleteWorkspace = (id: number) => {
-    appService.deleteWorkspace(id);
+    void appService.deleteWorkspace(id);
     setSelectedId(null);
   };
 
@@ -132,14 +132,14 @@ const AppContent: React.FC = () => {
         />
       ));
       if (!name || name.trim() === '') return;
-      appService.renameWorkspace(id, name.trim());
+      await appService.renameWorkspace(id, name.trim());
     } catch {
       /* user cancelled */
     }
   };
 
   const switchWorkspace = (id: number) => {
-    appService.switchWorkspace(id);
+    void appService.switchWorkspace(id);
     setSelectedId(null);
   };
 

--- a/packages/frontend/src/NoteCanvas.tsx
+++ b/packages/frontend/src/NoteCanvas.tsx
@@ -272,10 +272,12 @@ export const NoteCanvas: React.FC<NoteCanvasProps> = ({
     // Convert the menu position from screen space to board coordinates
     const boardX = (contextMenu.x - offset.x) / zoom;
     const boardY = (contextMenu.y - offset.y) / zoom;
-    const newId = pasteNote(appService, boardX, boardY);
-    if (newId != null) {
-      onSelect(newId);
-    }
+    void (async () => {
+      const newId = await pasteNote(appService, boardX, boardY);
+      if (newId != null) {
+        onSelect(newId);
+      }
+    })();
     setContextMenu(null);
   };
 

--- a/packages/frontend/src/services/Clipboard.ts
+++ b/packages/frontend/src/services/Clipboard.ts
@@ -18,14 +18,14 @@ export function copyNote(service: AppService, id: number): void {
   emitChange();
 }
 
-export function pasteNote(
+export async function pasteNote(
   service: AppService,
   x?: number,
   y?: number,
-): number | null {
+): Promise<number | null> {
   if (!clipboard) return null;
   const original = clipboard;
-  const newId = service.addNote();
+  const newId = await service.addNote();
   service.updateNote(newId, {
     content: original.content,
     width: original.width,

--- a/packages/frontend/src/services/KeyWatcher.ts
+++ b/packages/frontend/src/services/KeyWatcher.ts
@@ -58,9 +58,11 @@ export class KeyWatcher {
   }
 
   private pasteClipboard(): void {
-    const newId = pasteNote(this.service);
-    if (newId != null) {
-      this.opts.selectNote(newId);
-    }
+    void (async () => {
+      const newId = await pasteNote(this.service);
+      if (newId != null) {
+        this.opts.selectNote(newId);
+      }
+    })();
   }
 }


### PR DESCRIPTION
## Summary
- hook up `AppService` to use API helpers
- fetch workspaces on login and notes on workspace switch
- use async workspace and note creation
- adjust components for async service methods

## Testing
- `npm run lint` *(fails: Require statement not part of import statement)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c91226d2c832b8dcd9e269f50f85e