### PR TITLE
Add CORS headers to API Gateway default responses

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -816,6 +816,28 @@ resource "aws_api_gateway_method_settings" "default" {
   }
 }
 
+resource "aws_api_gateway_gateway_response" "default_4xx" {
+  rest_api_id   = aws_api_gateway_rest_api.main.id
+  response_type = "DEFAULT_4XX"
+
+  response_parameters = {
+    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'*'"
+    "gatewayresponse.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
+    "gatewayresponse.header.Access-Control-Allow-Methods" = "'GET,POST,PATCH,DELETE,OPTIONS'"
+  }
+}
+
+resource "aws_api_gateway_gateway_response" "default_5xx" {
+  rest_api_id   = aws_api_gateway_rest_api.main.id
+  response_type = "DEFAULT_5XX"
+
+  response_parameters = {
+    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'*'"
+    "gatewayresponse.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
+    "gatewayresponse.header.Access-Control-Allow-Methods" = "'GET,POST,PATCH,DELETE,OPTIONS'"
+  }
+}
+
 
 output "bucket_name" {
   value = aws_s3_bucket.frontend.bucket


### PR DESCRIPTION
## Summary
- configure gateway responses for API Gateway

## Testing
- `terraform init -input=false`
- `terraform validate`
- `terraform apply -auto-approve` *(fails: required variables and credentials missing)*
- `terraform plan -var="aws_region=us-east-1" ...` *(fails: no valid AWS credentials)*

------
https://chatgpt.com/codex/tasks/task_e_684cb14d93d4832b811c1f7aaee4c295