### PR TITLE
Add Lambda log group

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -313,6 +313,11 @@ data "archive_file" "backend" {
   output_path = "${path.module}/backend.zip"
 }
 
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/${aws_lambda_function.backend.function_name}"
+  retention_in_days = 14
+}
+
 resource "aws_lambda_function" "backend" {
   function_name = "sticky-notes-backend"
   filename         = data.archive_file.backend.output_path
@@ -327,6 +332,8 @@ resource "aws_lambda_function" "backend" {
       WS_ENDPOINT = "${aws_apigatewayv2_api.ws.api_endpoint}/${var.api_stage}"
     }
   }
+
+  depends_on = [aws_cloudwatch_log_group.lambda]
 }
 
 # API Gateway REST API


### PR DESCRIPTION
## Summary
- add a CloudWatch log group for the backend Lambda function
- ensure the backend Lambda waits for the log group to exist

## Testing
- `terraform init` *(fails: terraform not installed)*
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684cb45073f4832bacab07e00ab715ab