### PR TITLE
Fix Terraform log group dependency

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -314,7 +314,7 @@ data "archive_file" "backend" {
 }
 
 resource "aws_cloudwatch_log_group" "lambda" {
-  name              = "/aws/lambda/${aws_lambda_function.backend.function_name}"
+  name              = "/aws/lambda/sticky-notes-backend"
   retention_in_days = 14
 }
 


### PR DESCRIPTION
## Summary
- break cycle between Lambda and log group

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cb5636144832bae5d24309f96ea4a