### PR TITLE
Fix CORS headers for 401/403 responses

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -845,6 +845,28 @@ resource "aws_api_gateway_gateway_response" "default_5xx" {
   }
 }
 
+resource "aws_api_gateway_gateway_response" "unauthorized" {
+  rest_api_id   = aws_api_gateway_rest_api.main.id
+  response_type = "UNAUTHORIZED"
+
+  response_parameters = {
+    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'*'"
+    "gatewayresponse.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
+    "gatewayresponse.header.Access-Control-Allow-Methods" = "'GET,POST,PATCH,DELETE,OPTIONS'"
+  }
+}
+
+resource "aws_api_gateway_gateway_response" "access_denied" {
+  rest_api_id   = aws_api_gateway_rest_api.main.id
+  response_type = "ACCESS_DENIED"
+
+  response_parameters = {
+    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'*'"
+    "gatewayresponse.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
+    "gatewayresponse.header.Access-Control-Allow-Methods" = "'GET,POST,PATCH,DELETE,OPTIONS'"
+  }
+}
+
 
 output "bucket_name" {
   value = aws_s3_bucket.frontend.bucket


### PR DESCRIPTION
## Summary
- ensure API Gateway adds CORS headers on unauthorized errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cb8534fd4832ba28f000f94f1287d