### PR TITLE
Configure CORS allowed origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ distribution.
       -var="aws_region=<region>" \
       -var="acm_certificate_arn=<certificate-arn>" \
       -var="api_domain_name=<api-domain>" \
+      -var="allowed_origin=https://<your-domain>" \
       -var="google_client_id=<google-oauth-client-id>" \
       -var="google_client_secret=<google-oauth-secret>" \
       -var="callback_urls=[\"https://notes.example.com/callback\"]" \
@@ -247,3 +248,7 @@ For Windows cmd.exe:
 ```cmd
 set LAMBDA_FUNCTION_NAME="$(terraform -chdir=infra output -raw lambda_function_name)"
 ```
+
+The function also expects an `ALLOWED_ORIGIN` environment variable which should
+match the `allowed_origin` Terraform variable so that CORS headers are set
+correctly.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -184,6 +184,7 @@ resource "aws_acm_certificate_validation" "api" {
 
 locals {
   api_cert_arn = var.api_certificate_arn != null ? var.api_certificate_arn : aws_acm_certificate_validation.api[0].certificate_arn
+  allowed_origin = var.allowed_origin
 }
 
 # Cognito User Pool for authentication
@@ -330,6 +331,7 @@ resource "aws_lambda_function" "backend" {
     variables = {
       TABLE_NAME  = aws_dynamodb_table.main.name
       WS_ENDPOINT = "${aws_apigatewayv2_api.ws.api_endpoint}/${var.api_stage}"
+      ALLOWED_ORIGIN = local.allowed_origin
     }
   }
 
@@ -449,7 +451,7 @@ resource "aws_api_gateway_integration_response" "workspaces_options" {
   http_method = aws_api_gateway_method.workspaces_options.http_method
   status_code = aws_api_gateway_method_response.workspaces_options.status_code
   response_parameters = {
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${local.allowed_origin}'"
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,POST,PATCH,DELETE,OPTIONS'"
   }
@@ -524,7 +526,7 @@ resource "aws_api_gateway_integration_response" "workspace_id_options" {
   http_method = aws_api_gateway_method.workspace_id_options.http_method
   status_code = aws_api_gateway_method_response.workspace_id_options.status_code
   response_parameters = {
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${local.allowed_origin}'"
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,POST,PATCH,DELETE,OPTIONS'"
   }
@@ -597,7 +599,7 @@ resource "aws_api_gateway_integration_response" "notes_options" {
   http_method = aws_api_gateway_method.notes_options.http_method
   status_code = aws_api_gateway_method_response.notes_options.status_code
   response_parameters = {
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${local.allowed_origin}'"
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,POST,PATCH,DELETE,OPTIONS'"
   }
@@ -653,7 +655,7 @@ resource "aws_api_gateway_integration_response" "note_id_options" {
   http_method = aws_api_gateway_method.note_id_options.http_method
   status_code = aws_api_gateway_method_response.note_id_options.status_code
   response_parameters = {
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${local.allowed_origin}'"
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,POST,PATCH,DELETE,OPTIONS'"
   }
@@ -828,7 +830,7 @@ resource "aws_api_gateway_gateway_response" "default_4xx" {
   response_type = "DEFAULT_4XX"
 
   response_parameters = {
-    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'*'"
+    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'${local.allowed_origin}'"
     "gatewayresponse.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
     "gatewayresponse.header.Access-Control-Allow-Methods" = "'GET,POST,PATCH,DELETE,OPTIONS'"
   }
@@ -839,7 +841,7 @@ resource "aws_api_gateway_gateway_response" "default_5xx" {
   response_type = "DEFAULT_5XX"
 
   response_parameters = {
-    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'*'"
+    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'${local.allowed_origin}'"
     "gatewayresponse.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
     "gatewayresponse.header.Access-Control-Allow-Methods" = "'GET,POST,PATCH,DELETE,OPTIONS'"
   }
@@ -850,7 +852,7 @@ resource "aws_api_gateway_gateway_response" "unauthorized" {
   response_type = "UNAUTHORIZED"
 
   response_parameters = {
-    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'*'"
+    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'${local.allowed_origin}'"
     "gatewayresponse.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
     "gatewayresponse.header.Access-Control-Allow-Methods" = "'GET,POST,PATCH,DELETE,OPTIONS'"
   }
@@ -861,7 +863,7 @@ resource "aws_api_gateway_gateway_response" "access_denied" {
   response_type = "ACCESS_DENIED"
 
   response_parameters = {
-    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'*'"
+    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'${local.allowed_origin}'"
     "gatewayresponse.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
     "gatewayresponse.header.Access-Control-Allow-Methods" = "'GET,POST,PATCH,DELETE,OPTIONS'"
   }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -14,6 +14,12 @@ variable "domain_name" {
   default     = "notes.thalman.org"
 }
 
+variable "allowed_origin" {
+  description = "Allowed origin for CORS headers"
+  type        = string
+  default     = "https://${var.domain_name}"
+}
+
 variable "domain_name_root" {
   description = "Route53 hosted zone domain"
   type        = string

--- a/packages/backend/src/cors.ts
+++ b/packages/backend/src/cors.ts
@@ -1,5 +1,5 @@
 export const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': process.env.ALLOWED_ORIGIN || '*',
   'Access-Control-Allow-Headers': 'Content-Type,Authorization',
   'Access-Control-Allow-Methods': 'GET,POST,PATCH,DELETE,OPTIONS'
 };


### PR DESCRIPTION
## Summary
- add `allowed_origin` variable for Terraform
- expose `local.allowed_origin` and propagate it to the lambda
- use `ALLOWED_ORIGIN` env var throughout API Gateway responses
- read `ALLOWED_ORIGIN` in backend `CORS_HEADERS`
- document the new variable and environment setting

## Testing
- `npm run lint` *(fails: 33 errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cbd044870832baf9ec62c4f20f70d