### PR TITLE
Fix terraform allowed_origin default handling

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -184,7 +184,7 @@ resource "aws_acm_certificate_validation" "api" {
 
 locals {
   api_cert_arn = var.api_certificate_arn != null ? var.api_certificate_arn : aws_acm_certificate_validation.api[0].certificate_arn
-  allowed_origin = var.allowed_origin
+  allowed_origin = var.allowed_origin != null ? var.allowed_origin : "https://${var.domain_name}"
 }
 
 # Cognito User Pool for authentication

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -17,7 +17,7 @@ variable "domain_name" {
 variable "allowed_origin" {
   description = "Allowed origin for CORS headers"
   type        = string
-  default     = "https://${var.domain_name}"
+  default     = null
 }
 
 variable "domain_name_root" {


### PR DESCRIPTION
## Summary
- avoid using variables inside another variable's default
- compute allowed origin with a local expression

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cbf3f1aac832b96c1909f9f53fa68