### PR TITLE
Add CORS debugging guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,3 +252,7 @@ set LAMBDA_FUNCTION_NAME="$(terraform -chdir=infra output -raw lambda_function_n
 The function also expects an `ALLOWED_ORIGIN` environment variable which should
 match the `allowed_origin` Terraform variable so that CORS headers are set
 correctly.
+
+### Debugging CORS issues
+
+If API calls fail due to CORS errors, see [docs/cors-debugging.md](docs/cors-debugging.md) for steps to inspect the preflight `OPTIONS` request and the actual `GET` response.

--- a/docs/cors-debugging.md
+++ b/docs/cors-debugging.md
@@ -1,0 +1,21 @@
+# CORS Debugging Guide
+
+When the backend rejects requests due to incorrect CORS headers, use your browser's developer tools to verify the response.
+
+1. **Open the Network panel**
+   - In most browsers press `F12` to open Developer Tools and switch to the **Network** tab.
+   - Reload the page so the requests appear in the list.
+2. **Inspect the preflight request**
+   - Find the `OPTIONS` call to your API endpoint and click it.
+   - In the **Headers** section confirm the response includes:
+     - `Access-Control-Allow-Origin`
+     - `Access-Control-Allow-Methods`
+     - `Access-Control-Allow-Headers`
+3. **Inspect the actual request**
+   - Locate the subsequent `GET` request for the same endpoint.
+   - Check that the same CORS headers are present in this response as well.
+
+CORS configuration is controlled by the `ALLOWED_ORIGIN` environment variable defined in
+[`packages/backend/src/cors.ts`](../packages/backend/src/cors.ts). For `GET` requests
+this value must exactly match your frontend's origin or the browser will reject the
+response.


### PR DESCRIPTION
## Summary
- add `docs/cors-debugging.md` to show how to verify CORS headers
- link new doc from README under deployment section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd088a53c832b85c0fecd0f61faf2