### PR TITLE
Add error handling wrapper

### DIFF
--- a/packages/backend/src/cors.ts
+++ b/packages/backend/src/cors.ts
@@ -1,5 +1,18 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+
 export const CORS_HEADERS = {
   'Access-Control-Allow-Origin': process.env.ALLOWED_ORIGIN as string,
   'Access-Control-Allow-Headers': 'Content-Type,Authorization',
   'Access-Control-Allow-Methods': 'GET,POST,PATCH,DELETE,OPTIONS'
 };
+
+export function withErrorHandling(fn: APIGatewayProxyHandler): APIGatewayProxyHandler {
+  return async (event, context) => {
+    try {
+      return await fn(event, context);
+    } catch (err) {
+      console.error(err);
+      return { statusCode: 500, headers: CORS_HEADERS, body: 'Internal Server Error' };
+    }
+  };
+}

--- a/packages/backend/src/handler.ts
+++ b/packages/backend/src/handler.ts
@@ -1,14 +1,14 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
-import { CORS_HEADERS } from './cors';
+import { CORS_HEADERS, withErrorHandling } from './cors';
 
 // Minimal Lambda function used during development. It simply returns a JSON
 // payload. Real API logic would go here.
 
-export const handler: APIGatewayProxyHandler = async () => {
+export const handler = withErrorHandling(async () => {
   // Respond with a simple greeting
   return {
     statusCode: 200,
     headers: CORS_HEADERS,
     body: JSON.stringify({ message: 'Hello from backend' })
   };
-};
+});

--- a/packages/backend/src/notes.ts
+++ b/packages/backend/src/notes.ts
@@ -3,12 +3,12 @@ import { DynamoDB } from 'aws-sdk';
 import { Note, Workspace } from '@sticky-notes/shared';
 import { getUserId, hasWorkspaceAccess } from './auth';
 import { broadcastWorkspaceEvent } from './websocket';
-import { CORS_HEADERS } from './cors';
+import { CORS_HEADERS, withErrorHandling } from './cors';
 
 const TABLE_NAME = process.env.TABLE_NAME as string;
 const db = new DynamoDB.DocumentClient();
 
-export const createNote: APIGatewayProxyHandler = async (event) => {
+export const createNote = withErrorHandling(async (event) => {
   const userId = getUserId(event);
   const input: Partial<Note & { workspaceId: number }> = event.body
     ? JSON.parse(event.body)
@@ -65,9 +65,9 @@ export const createNote: APIGatewayProxyHandler = async (event) => {
     headers: CORS_HEADERS,
     body: JSON.stringify(note),
   };
-};
+});
 
-export const updateNote: APIGatewayProxyHandler = async (event) => {
+export const updateNote = withErrorHandling(async (event) => {
   const userId = getUserId(event);
   const id = event.pathParameters?.id;
   if (!id) {
@@ -138,9 +138,9 @@ export const updateNote: APIGatewayProxyHandler = async (event) => {
     headers: CORS_HEADERS,
     body: JSON.stringify(updated.Attributes),
   };
-};
+});
 
-export const listNotes: APIGatewayProxyHandler = async (event) => {
+export const listNotes = withErrorHandling(async (event) => {
   const userId = getUserId(event);
   const workspaceId = event.queryStringParameters?.workspaceId;
   if (!workspaceId) {
@@ -175,6 +175,6 @@ export const listNotes: APIGatewayProxyHandler = async (event) => {
     headers: CORS_HEADERS,
     body: JSON.stringify(notes),
   };
-};
+});
 
 export { createNote as postNotes, updateNote as patchNote, listNotes as getNotes };

--- a/packages/backend/src/workspaces.ts
+++ b/packages/backend/src/workspaces.ts
@@ -3,7 +3,7 @@ import { DynamoDB } from 'aws-sdk';
 import { Workspace } from '@sticky-notes/shared';
 import { getUserId, hasWorkspaceAccess } from './auth';
 import { broadcastWorkspaceEvent } from './websocket';
-import { CORS_HEADERS } from './cors';
+import { CORS_HEADERS, withErrorHandling } from './cors';
 
 const TABLE_NAME = process.env.TABLE_NAME as string;
 const db = new DynamoDB.DocumentClient();
@@ -13,7 +13,7 @@ const db = new DynamoDB.DocumentClient();
  * returns the created Workspace object. This is a placeholder implementation
  * that simply echoes the provided values with a generated id.
  */
-export const createWorkspace: APIGatewayProxyHandler = async (event) => {
+export const createWorkspace = withErrorHandling(async (event) => {
   const userId = getUserId(event);
   const input: Partial<Workspace> = event.body ? JSON.parse(event.body) : {};
 
@@ -53,13 +53,13 @@ export const createWorkspace: APIGatewayProxyHandler = async (event) => {
     headers: CORS_HEADERS,
     body: JSON.stringify(workspace),
   };
-};
+});
 
 /**
  * Retrieve a workspace by id. In this placeholder implementation the returned
  * data is not persisted anywhere and simply returns an example Workspace.
  */
-export const getWorkspace: APIGatewayProxyHandler = async (event) => {
+export const getWorkspace = withErrorHandling(async (event) => {
   const userId = getUserId(event);
   const id = event.pathParameters?.id;
   if (!id) {
@@ -84,13 +84,13 @@ export const getWorkspace: APIGatewayProxyHandler = async (event) => {
     headers: CORS_HEADERS,
     body: JSON.stringify(workspace),
   };
-};
+});
 
 /**
  * Update an existing workspace. Accepts partial Workspace fields in the request
  * body and returns the updated object. Data is not persisted yet.
  */
-export const updateWorkspace: APIGatewayProxyHandler = async (event) => {
+export const updateWorkspace = withErrorHandling(async (event) => {
   const userId = getUserId(event);
   const id = event.pathParameters?.id;
   if (!id) {
@@ -152,12 +152,12 @@ export const updateWorkspace: APIGatewayProxyHandler = async (event) => {
     headers: CORS_HEADERS,
     body: JSON.stringify(updated.Attributes),
   };
-};
+});
 
 /**
  * Delete a workspace. Simply returns a 204 status code to indicate success.
  */
-export const deleteWorkspace: APIGatewayProxyHandler = async (event) => {
+export const deleteWorkspace = withErrorHandling(async (event) => {
   const userId = getUserId(event);
   const id = event.pathParameters?.id;
   if (!id) {
@@ -186,12 +186,12 @@ export const deleteWorkspace: APIGatewayProxyHandler = async (event) => {
     headers: CORS_HEADERS,
     body: '',
   };
-};
+});
 
 /**
  * List workspaces accessible to the caller. Returns a few example items.
  */
-export const listWorkspaces: APIGatewayProxyHandler = async (event) => {
+export const listWorkspaces = withErrorHandling(async (event) => {
   const userId = getUserId(event);
 
   const user = await db
@@ -222,4 +222,4 @@ export const listWorkspaces: APIGatewayProxyHandler = async (event) => {
     headers: CORS_HEADERS,
     body: JSON.stringify(workspaces),
   };
-};
+});


### PR DESCRIPTION
## Summary
- add `withErrorHandling` helper to wrap lambda handlers
- wrap all API handlers in backend with global error handling

## Testing
- `npm test --silent --prefix packages/backend`

------
https://chatgpt.com/codex/tasks/task_e_684cd19696f0832b9c01e7750c2eab4b