### PR TITLE
Add optional X-Ray tracing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ distribution.
    `cognito_hosted_ui_domain` values used when configuring the frontend
    authentication flow.
 
+To enable AWS X-Ray tracing for the Lambda and API Gateway stages, pass
+`-var="enable_xray=true"` when running `terraform apply`.
+Tracing is disabled by default.
+
 Terraform also configures a custom domain for the API. If `api_certificate_arn`
 is omitted, Terraform will request a new ACM certificate in the `us-east-1`
 region and validate it using Route53 DNS records so the backend can be

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -79,3 +79,9 @@ variable "api_stage" {
   type        = string
   default     = "prod"
 }
+
+variable "enable_xray" {
+  description = "Enable AWS X-Ray tracing for Lambda and API Gateway"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- add `enable_xray` Terraform variable
- toggle X-Ray tracing for Lambda and API Gateway stages
- conditionally attach X-Ray IAM policy
- document how to enable tracing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd9c63a3c832b82d124ed4c8dc97d