### PR TITLE
Enable AWS X-Ray for backend lambdas

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -8,7 +8,8 @@
     "test": "TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register test/run-tests.js"
   },
   "dependencies": {
-    "aws-sdk": "^2.0.0"
+    "aws-sdk": "^2.0.0",
+    "aws-xray-sdk": "^3.10.3"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/packages/backend/src/handler.ts
+++ b/packages/backend/src/handler.ts
@@ -1,3 +1,5 @@
+import * as AWSXRay from 'aws-xray-sdk';
+AWSXRay.captureAWS(require('aws-sdk'));
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import { CORS_HEADERS, withErrorHandling } from './cors';
 

--- a/packages/backend/src/notes.ts
+++ b/packages/backend/src/notes.ts
@@ -1,3 +1,5 @@
+import * as AWSXRay from 'aws-xray-sdk';
+AWSXRay.captureAWS(require('aws-sdk'));
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import { DynamoDB } from 'aws-sdk';
 import { Note, Workspace } from '@sticky-notes/shared';

--- a/packages/backend/src/websocket.ts
+++ b/packages/backend/src/websocket.ts
@@ -1,3 +1,5 @@
+import * as AWSXRay from 'aws-xray-sdk';
+AWSXRay.captureAWS(require('aws-sdk'));
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import { DynamoDB, ApiGatewayManagementApi } from 'aws-sdk';
 

--- a/packages/backend/src/workspaces.ts
+++ b/packages/backend/src/workspaces.ts
@@ -1,3 +1,5 @@
+import * as AWSXRay from 'aws-xray-sdk';
+AWSXRay.captureAWS(require('aws-sdk'));
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import { DynamoDB } from 'aws-sdk';
 import { Workspace } from '@sticky-notes/shared';


### PR DESCRIPTION
## Summary
- add `aws-xray-sdk` to backend dependencies
- capture AWS SDK clients in all backend handlers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cdac9edf0832b97d6baad7d7c45a2