### PR TITLE
Fix stage configuration for WebSocket API

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -754,7 +754,6 @@ resource "aws_apigatewayv2_stage" "ws" {
   api_id      = aws_apigatewayv2_api.ws.id
   name        = var.api_stage
   auto_deploy = true
-  xray_tracing_enabled = var.enable_xray
 }
 
 resource "aws_lambda_permission" "ws" {


### PR DESCRIPTION
## Summary
- remove unsupported X-Ray setting from `aws_apigatewayv2_stage`

## Testing
- `npm test`
- `npm run lint` *(fails: unexpected any / no-var-requires errors)*

------
https://chatgpt.com/codex/tasks/task_e_684cdbe3867c832baf591afab1bf10d4