### PR TITLE
Fix TypeScript handler typing

### DIFF
--- a/packages/backend/src/cors.ts
+++ b/packages/backend/src/cors.ts
@@ -1,4 +1,9 @@
-import { APIGatewayProxyHandler } from 'aws-lambda';
+import {
+  APIGatewayProxyEvent,
+  APIGatewayProxyHandler,
+  APIGatewayProxyResult,
+  Context,
+} from 'aws-lambda';
 
 export const CORS_HEADERS = {
   'Access-Control-Allow-Origin': process.env.ALLOWED_ORIGIN as string,
@@ -6,7 +11,12 @@ export const CORS_HEADERS = {
   'Access-Control-Allow-Methods': 'GET,POST,PATCH,DELETE,OPTIONS'
 };
 
-export function withErrorHandling(fn: APIGatewayProxyHandler): APIGatewayProxyHandler {
+type AsyncHandler = (
+  event: APIGatewayProxyEvent,
+  context: Context
+) => Promise<APIGatewayProxyResult>;
+
+export function withErrorHandling(fn: AsyncHandler): APIGatewayProxyHandler {
   return async (event, context) => {
     try {
       return await fn(event, context);


### PR DESCRIPTION
## Summary
- fix handler typing in `withErrorHandling` helper

## Testing
- `npm run build --workspace packages/backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cdd148be0832b840fd46f15b07b91