### PR TITLE
Add root principal to KMS policy

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -346,7 +346,20 @@ resource "aws_iam_role_policy" "lambda_dynamo" {
   policy = data.aws_iam_policy_document.lambda_dynamo.json
 }
 
+# Current account details used for KMS policy
+data "aws_caller_identity" "current" {}
+
 data "aws_iam_policy_document" "lambda_kms" {
+  # Allow account root to manage the key
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
   statement {
     principals {
       type        = "Service"


### PR DESCRIPTION
## Summary
- include `aws_caller_identity` to get current account
- update the Lambda KMS key policy so the account root can manage the key

## Testing
- `npm test`
- `npm run lint` *(fails: 40 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ce2ebcef0832b85e7be6dd317e081