### PR TITLE
Update CloudFront distribution for API Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ distribution.
       -var="bucket_name=<your-bucket>" \
       -var="aws_region=<region>" \
       -var="acm_certificate_arn=<certificate-arn>" \
-      -var="api_domain_name=<api-domain>" \
       -var="allowed_origin=https://<your-domain>" \
       -var="google_client_id=<google-oauth-client-id>" \
       -var="google_client_secret=<google-oauth-secret>" \
@@ -164,10 +163,6 @@ To enable AWS X-Ray tracing for the Lambda and API Gateway stages, pass
 `-var="enable_xray=true"` when running `terraform apply`.
 Tracing is disabled by default.
 
-Terraform also configures a custom domain for the API. If `api_certificate_arn`
-is omitted, Terraform will request a new ACM certificate in the `us-east-1`
-region and validate it using Route53 DNS records so the backend can be
-accessed via HTTPS.
 
 ### Authentication configuration
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -31,17 +31,6 @@ variable "acm_certificate_arn" {
   type        = string
 }
 
-variable "api_domain_name" {
-  description = "Fully qualified domain name for the API"
-  type        = string
-  default     = "api.notes.thalman.org"
-}
-
-variable "api_certificate_arn" {
-  description = "ACM certificate ARN for the API domain. If null, a certificate will be created in us-east-1"
-  type        = string
-  default     = null
-}
 
 variable "google_client_id" {
   description = "Google OAuth client ID"


### PR DESCRIPTION
## Summary
- configure CloudFront to route `/api/*` to API Gateway
- remove API custom domain resources
- simplify variables
- update documentation

## Testing
- `npm test`
- `terraform fmt infra/main.tf`
- `terraform fmt infra/variables.tf`


------
https://chatgpt.com/codex/tasks/task_e_684cee9d4b2c832bb34bfb1e1835f669