### PR TITLE
Fix CloudFront config

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -115,6 +115,7 @@ resource "aws_cloudfront_distribution" "frontend" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
 
@@ -147,6 +148,9 @@ resource "aws_cloudfront_distribution" "frontend" {
     forwarded_values {
       query_string = true
       headers      = ["Authorization", "Content-Type"]
+      cookies {
+        forward = "none"
+      }
     }
   }
   restrictions {


### PR DESCRIPTION
## Summary
- add required `origin_ssl_protocols` block to CloudFront custom origin
- ensure cookies block exists in ordered cache behavior

## Testing
- `npm test`
- `terraform fmt -check`

------
https://chatgpt.com/codex/tasks/task_e_684cff3c0dc0832b8185a1c2d0bf5676