### PR TITLE
Fix backend lambda handler routing

### DIFF
--- a/packages/backend/src/error.ts
+++ b/packages/backend/src/error.ts
@@ -1,8 +1,11 @@
-import { APIGatewayProxyEvent, APIGatewayProxyHandler, APIGatewayProxyResult, Context } from 'aws-lambda';
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
 
-type AsyncHandler = (event: APIGatewayProxyEvent, context: Context) => Promise<APIGatewayProxyResult>;
+export type APIGatewayHandler = (
+  event: APIGatewayProxyEvent,
+  context: Context,
+) => Promise<APIGatewayProxyResult>;
 
-export function withErrorHandling(fn: AsyncHandler): APIGatewayProxyHandler {
+export function withErrorHandling(fn: APIGatewayHandler): APIGatewayHandler {
   return async (event, context) => {
     try {
       return await fn(event, context);

--- a/packages/backend/src/handler.ts
+++ b/packages/backend/src/handler.ts
@@ -1,6 +1,6 @@
 import * as AWSXRay from 'aws-xray-sdk';
 AWSXRay.captureAWS(require('aws-sdk'));
-import { APIGatewayProxyHandler } from 'aws-lambda';
+import type { APIGatewayHandler } from './error';
 import { withErrorHandling } from './error';
 import {
   createWorkspace,
@@ -12,7 +12,7 @@ import {
 import { createNote, updateNote, listNotes } from './notes';
 import { subscribe, unsubscribe, disconnect } from './websocket';
 
-export const handler: APIGatewayProxyHandler = withErrorHandling(
+export const handler: APIGatewayHandler = withErrorHandling(
   async (event, context) => {
     // Handle WebSocket routes first
     const routeKey = (event.requestContext as any).routeKey as string | undefined;

--- a/packages/backend/src/notes.ts
+++ b/packages/backend/src/notes.ts
@@ -1,6 +1,5 @@
 import * as AWSXRay from 'aws-xray-sdk';
 AWSXRay.captureAWS(require('aws-sdk'));
-import { APIGatewayProxyHandler } from 'aws-lambda';
 import { DynamoDB } from 'aws-sdk';
 import { Note, Workspace } from '@sticky-notes/shared';
 import { getUserId, hasWorkspaceAccess } from './auth';

--- a/packages/backend/src/websocket.ts
+++ b/packages/backend/src/websocket.ts
@@ -1,6 +1,7 @@
 import * as AWSXRay from 'aws-xray-sdk';
 AWSXRay.captureAWS(require('aws-sdk'));
-import { APIGatewayProxyHandler } from 'aws-lambda';
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import type { APIGatewayHandler } from './error';
 import { DynamoDB, ApiGatewayManagementApi } from 'aws-sdk';
 
 const TABLE_NAME = process.env.TABLE_NAME as string;
@@ -9,7 +10,10 @@ const WS_ENDPOINT = process.env.WS_ENDPOINT as string;
 const db = new DynamoDB.DocumentClient();
 const api = WS_ENDPOINT ? new ApiGatewayManagementApi({ endpoint: WS_ENDPOINT }) : undefined;
 
-export const subscribe: APIGatewayProxyHandler = async (event) => {
+export const subscribe: APIGatewayHandler = async (
+  event: APIGatewayProxyEvent,
+  _context: Context,
+) => {
   const connectionId = event.requestContext.connectionId as string;
   const body = event.body ? JSON.parse(event.body) : {};
   const workspaceId = body.workspaceId;
@@ -30,7 +34,10 @@ export const subscribe: APIGatewayProxyHandler = async (event) => {
   return { statusCode: 200, body: 'Subscribed' };
 };
 
-export const unsubscribe: APIGatewayProxyHandler = async (event) => {
+export const unsubscribe: APIGatewayHandler = async (
+  event: APIGatewayProxyEvent,
+  _context: Context,
+) => {
   const connectionId = event.requestContext.connectionId as string;
   const body = event.body ? JSON.parse(event.body) : {};
   const workspaceId = body.workspaceId;
@@ -51,7 +58,10 @@ export const unsubscribe: APIGatewayProxyHandler = async (event) => {
   return { statusCode: 200, body: 'Unsubscribed' };
 };
 
-export const disconnect: APIGatewayProxyHandler = async (event) => {
+export const disconnect: APIGatewayHandler = async (
+  event: APIGatewayProxyEvent,
+  _context: Context,
+) => {
   const connectionId = event.requestContext.connectionId as string;
 
   const scan = await db

--- a/packages/backend/src/workspaces.ts
+++ b/packages/backend/src/workspaces.ts
@@ -1,6 +1,5 @@
 import * as AWSXRay from 'aws-xray-sdk';
 AWSXRay.captureAWS(require('aws-sdk'));
-import { APIGatewayProxyHandler } from 'aws-lambda';
 import { DynamoDB } from 'aws-sdk';
 import { Workspace } from '@sticky-notes/shared';
 import { getUserId, hasWorkspaceAccess } from './auth';


### PR DESCRIPTION
## Summary
- update error handling wrapper to provide custom `APIGatewayHandler` type
- use the new type in handler and websocket functions
- remove unused API Gateway handler imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d173816e4832ba8cdd534eec0e8cd