### PR TITLE
Use prebuilt Lambda bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,12 @@ distribution.
    cd infra
    terraform init
    ```
-2. Apply the configuration, providing a unique S3 bucket name, Cognito settings
+2. Build the backend package so Terraform can deploy the Lambda code:
+   ```bash
+   npm run deploy:backend
+   ```
+   This command creates `packages/backend/backend.zip` which Terraform uses for the Lambda function.
+3. Apply the configuration, providing a unique S3 bucket name, Cognito settings
    and AWS region:
    ```bash
     terraform apply \

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -363,12 +363,6 @@ resource "aws_kms_key" "lambda_env_key" {
   policy      = data.aws_iam_policy_document.lambda_kms.json
 }
 
-# Package Lambda code from the compiled backend
-data "archive_file" "backend" {
-  type        = "zip"
-  source_dir  = "${path.module}/../packages/backend/dist"
-  output_path = "${path.module}/backend.zip"
-}
 
 resource "aws_cloudwatch_log_group" "lambda" {
   name              = "/aws/lambda/sticky-notes-backend"
@@ -377,8 +371,8 @@ resource "aws_cloudwatch_log_group" "lambda" {
 
 resource "aws_lambda_function" "backend" {
   function_name    = "sticky-notes-backend"
-  filename         = data.archive_file.backend.output_path
-  source_code_hash = data.archive_file.backend.output_base64sha256
+  filename         = "${path.module}/../packages/backend/backend.zip"
+  source_code_hash = filebase64sha256("${path.module}/../packages/backend/backend.zip")
   handler          = "handler.handler"
   runtime          = "nodejs18.x"
   role             = aws_iam_role.lambda_exec.arn


### PR DESCRIPTION
## Summary
- reference backend.zip directly in Lambda function
- mention running `npm run deploy:backend` before Terraform apply

## Testing
- `npm test`
- `terraform plan -target=aws_lambda_function.backend` *(fails: No valid credential sources found)*

------
https://chatgpt.com/codex/tasks/task_e_684e3e09fbec832ba5089fab62826bcb