### PR TITLE
ensure backend deploy checks dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Update the Lambda function after making backend changes with:
 npm run deploy:backend
 ```
 
-The script compiles the backend, packages the Lambda code using the Node [archiver](https://www.npmjs.com/package/archiver) library (so no separate `zip` tool is required) and uploads it with the AWS CLI. All production dependencies are automatically copied into the bundle so packages like `aws-xray-sdk-core` are available at runtime. Set the `LAMBDA_FUNCTION_NAME` environment variable to the function name, which can be retrieved from Terraform outputs:
+The script compiles the backend, packages the Lambda code using the Node [archiver](https://www.npmjs.com/package/archiver) library (so no separate `zip` tool is required) and uploads it with the AWS CLI. All production dependencies are automatically copied into the bundle so packages like `aws-xray-sdk-core` are available at runtime. The deployment script expects the repository's root `node_modules` directory to exist, so run `npm install` from the project root before deploying. Set the `LAMBDA_FUNCTION_NAME` environment variable to the function name, which can be retrieved from Terraform outputs:
 
 For Bash or other Unix shells:
 

--- a/scripts/deploy_backend.js
+++ b/scripts/deploy_backend.js
@@ -1,7 +1,6 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const archiver = require('archiver');
 
 function run(cmd, opts = {}) {
   console.log(cmd);
@@ -15,6 +14,17 @@ if (!functionName) {
   console.error('LAMBDA_FUNCTION_NAME environment variable must be set');
   process.exit(1);
 }
+
+// Ensure root dependencies are installed
+const rootNodeModules = path.join(__dirname, '..', 'node_modules');
+if (!fs.existsSync(rootNodeModules)) {
+  console.error(
+    'Top-level node_modules folder not found. Run "npm install" before deploying.'
+  );
+  process.exit(1);
+}
+
+const archiver = require('archiver');
 
 // Build the backend package
 run('npm run build --workspace packages/backend');


### PR DESCRIPTION
## Summary
- halt backend deployment if `node_modules` is missing
- mention requirement in Backend Deployment docs

## Testing
- `npm test`
- `PATH=$(pwd)/fakebin:$PATH LAMBDA_FUNCTION_NAME=dummy npm run deploy:backend > /tmp/deploy_missing.log 2>&1`
- `PATH=$(pwd)/fakebin:$PATH LAMBDA_FUNCTION_NAME=dummy npm run deploy:backend > /tmp/deploy_success.log 2>&1`

------
https://chatgpt.com/codex/tasks/task_e_684e429d5058832bbd9e2663c78241a3